### PR TITLE
Add mock data fallback for booking calendar

### DIFF
--- a/src/app/booking/page.tsx
+++ b/src/app/booking/page.tsx
@@ -4,23 +4,47 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { RoomService } from '@/lib/firebase/hotel-service'
+import { RoomService as LiveRoomService } from '@/lib/firebase/hotel-service'
+import { RoomService as MockRoomService } from '@/lib/firebase/hotel-service-mock'
 import { Room } from '@/types/hotel'
 import BookingFlow from '@/components/booking/BookingFlow'
 
 export default function BookingPage() {
   const [availableRooms, setAvailableRooms] = useState<Room[]>([])
   const [loading, setLoading] = useState(true)
+  const [isUsingFallbackData, setIsUsingFallbackData] = useState(false)
+  const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
     const loadAvailableRooms = async () => {
       try {
-        const rooms = await RoomService.getRooms({
+        setError(null)
+        const rooms = await LiveRoomService.getRooms({
           status: 'available'
         })
+        if (!rooms.length) {
+          throw new Error('No rooms returned from live service')
+        }
         setAvailableRooms(rooms)
+        setIsUsingFallbackData(false)
       } catch (error) {
-        console.error('Failed to load available rooms:', error)
+        console.warn('Failed to load live room data, attempting fallback mock data:', error)
+
+        try {
+          const mockRooms = await MockRoomService.getRooms({
+            status: 'available'
+          })
+
+          if (!mockRooms.length) {
+            throw new Error('No mock rooms available')
+          }
+
+          setAvailableRooms(mockRooms)
+          setIsUsingFallbackData(true)
+        } catch (mockError) {
+          console.error('Failed to load fallback room data:', mockError)
+          setError("We're having trouble loading room availability right now. Please try again shortly.")
+        }
       } finally {
         setLoading(false)
       }
@@ -40,10 +64,22 @@ export default function BookingPage() {
     )
   }
 
+  if (error) {
+    return (
+      <main className="min-h-screen bg-gradient-to-br from-slate-900 to-slate-950 flex items-center justify-center">
+        <div className="max-w-md text-center space-y-4 px-4">
+          <h1 className="text-3xl font-semibold text-white">Availability Unavailable</h1>
+          <p className="text-slate-400">{error}</p>
+        </div>
+      </main>
+    )
+  }
+
   return (
     <BookingFlow
       initialStep="room-selection"
       availableRooms={availableRooms}
+      isUsingMockData={isUsingFallbackData}
     />
   )
 }

--- a/src/components/booking/BookingFlow.tsx
+++ b/src/components/booking/BookingFlow.tsx
@@ -20,11 +20,13 @@ import { PaymentStep } from '@/components/payment/PaymentStep'
 interface BookingFlowProps {
   initialStep?: BookingFlowState['currentStep']
   availableRooms?: any[]
+  isUsingMockData?: boolean
 }
 
 const BookingFlow: React.FC<BookingFlowProps> = ({
   initialStep = 'room-selection',
-  availableRooms = []
+  availableRooms = [],
+  isUsingMockData = false
 }) => {
   const router = useRouter()
   const { user } = useAuth()
@@ -206,6 +208,12 @@ const BookingFlow: React.FC<BookingFlowProps> = ({
                 Drag rooms to your preferred dates or browse our selection to create your Highland getaway.
               </p>
             </div>
+
+            {isUsingMockData && (
+              <div className="rounded-2xl border border-amber-400/40 bg-amber-400/10 px-4 py-3 text-sm text-amber-100">
+                Live availability isn&apos;t connected right now, so we&apos;re showing demo rooms that you can drag onto the calendar.
+              </div>
+            )}
 
             <DragDropCalendar
               availableRooms={availableRooms}

--- a/src/components/booking/DragDropCalendar.tsx
+++ b/src/components/booking/DragDropCalendar.tsx
@@ -6,7 +6,8 @@
 import { useState, useEffect, useMemo } from 'react'
 import { DragDropContext, Droppable, Draggable, DropResult } from 'react-beautiful-dnd'
 import { DailyAvailability, Room, RoomType, PackageType } from '@/types/hotel'
-import { AvailabilityService } from '@/lib/firebase/hotel-service'
+import { AvailabilityService as LiveAvailabilityService } from '@/lib/firebase/hotel-service'
+import { AvailabilityService as MockAvailabilityService } from '@/lib/firebase/hotel-service-mock'
 import { useCartStore, PACKAGE_OPTIONS } from '@/store/cartStore'
 
 interface DragDropCalendarProps {
@@ -117,6 +118,7 @@ const DragDropCalendar: React.FC<DragDropCalendarProps> = ({
   const [loading, setLoading] = useState(false)
   const [selectedPackage, setSelectedPackage] = useState<PackageType>('room-only')
   const [dragOverDate, setDragOverDate] = useState<string | null>(null)
+  const [usingMockAvailability, setUsingMockAvailability] = useState(false)
 
   const { addRoomFromDrop } = useCartStore()
 
@@ -162,22 +164,52 @@ const DragDropCalendar: React.FC<DragDropCalendarProps> = ({
         const data: Record<string, DailyAvailability> = {}
 
         const currentDate = new Date(startOfMonth)
+        let fallbackActivated = false
+        let fallbackLogged = false
+
+        const logFallback = (error?: unknown) => {
+          if (fallbackLogged) return
+          console.warn('Falling back to demo availability data for booking calendar.', error)
+          fallbackLogged = true
+        }
+
         while (currentDate <= endOfMonth) {
           const dateStr = currentDate.toISOString().split('T')[0]
-          try {
-            const dayAvailability = await AvailabilityService.getDailyAvailability(dateStr)
-            if (dayAvailability) {
-              data[dateStr] = dayAvailability
+          let dayAvailability: DailyAvailability | null = null
+
+          if (!fallbackActivated) {
+            try {
+              dayAvailability = await LiveAvailabilityService.getDailyAvailability(dateStr)
+              if (!dayAvailability) {
+                fallbackActivated = true
+                logFallback()
+              }
+            } catch (error) {
+              fallbackActivated = true
+              logFallback(error)
             }
-          } catch (error) {
-            console.warn(`Failed to load availability for ${dateStr}:`, error)
           }
+
+          if (fallbackActivated && !dayAvailability) {
+            try {
+              dayAvailability = await MockAvailabilityService.getDailyAvailability(dateStr)
+            } catch (mockError) {
+              console.error(`Failed to load fallback availability for ${dateStr}:`, mockError)
+            }
+          }
+
+          if (dayAvailability) {
+            data[dateStr] = dayAvailability
+          }
+
           currentDate.setDate(currentDate.getDate() + 1)
         }
 
+        setUsingMockAvailability(fallbackActivated)
         setAvailabilityData(data)
       } catch (error) {
         console.error('Failed to load availability data:', error)
+        setAvailabilityData({})
       } finally {
         setLoading(false)
       }
@@ -311,6 +343,12 @@ const DragDropCalendar: React.FC<DragDropCalendarProps> = ({
             </select>
           </div>
         </div>
+
+        {usingMockAvailability && (
+          <div className="mb-6 rounded-2xl border border-amber-400/40 bg-amber-400/10 px-4 py-3 text-sm text-amber-100">
+            We&apos;re displaying sample availability data while the live calendar loads.
+          </div>
+        )}
 
         <div className="grid lg:grid-cols-3 gap-6">
           {/* Available Rooms */}


### PR DESCRIPTION
## Summary
- add a mock-data fallback on the booking page so visitors see draggable rooms even when live inventory is unavailable
- surface an informational banner in the booking flow whenever demo rooms are being shown
- update the drag-and-drop calendar to reuse mock availability data and warn users when the fallback is active

## Testing
- npm run lint *(fails: repository already has numerous lint violations unrelated to this change)*
- npm run type-check *(fails: existing missing Stripe type dependencies and other pre-existing TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68d2fa34250c833292e220c2c6276fcc