### PR TITLE
Improve booking page mock data fallbacks

### DIFF
--- a/src/app/booking/page.tsx
+++ b/src/app/booking/page.tsx
@@ -5,6 +5,7 @@
 
 import { useState, useEffect } from 'react'
 import { RoomService } from '@/lib/firebase/hotel-service'
+import { RoomService as MockRoomService } from '@/lib/firebase/hotel-service-mock'
 import { Room } from '@/types/hotel'
 import BookingFlow from '@/components/booking/BookingFlow'
 
@@ -14,13 +15,31 @@ export default function BookingPage() {
 
   useEffect(() => {
     const loadAvailableRooms = async () => {
+      setLoading(true)
       try {
         const rooms = await RoomService.getRooms({
           status: 'available'
         })
-        setAvailableRooms(rooms)
+        if (rooms.length > 0) {
+          setAvailableRooms(rooms)
+          return
+        }
+        // Fallback to mock data when no live data is available
+        const mockRooms = await MockRoomService.getRooms({
+          status: 'available'
+        })
+        setAvailableRooms(mockRooms)
       } catch (error) {
         console.error('Failed to load available rooms:', error)
+        try {
+          const mockRooms = await MockRoomService.getRooms({
+            status: 'available'
+          })
+          setAvailableRooms(mockRooms)
+        } catch (mockError) {
+          console.error('Failed to load mock rooms:', mockError)
+          setAvailableRooms([])
+        }
       } finally {
         setLoading(false)
       }

--- a/src/components/booking/DragDropCalendar.tsx
+++ b/src/components/booking/DragDropCalendar.tsx
@@ -6,7 +6,8 @@
 import { useState, useEffect, useMemo } from 'react'
 import { DragDropContext, Droppable, Draggable, DropResult } from 'react-beautiful-dnd'
 import { DailyAvailability, Room, RoomType, PackageType } from '@/types/hotel'
-import { AvailabilityService } from '@/lib/firebase/hotel-service'
+import { AvailabilityService as FirebaseAvailabilityService } from '@/lib/firebase/hotel-service'
+import { AvailabilityService as MockAvailabilityService } from '@/lib/firebase/hotel-service-mock'
 import { useCartStore, PACKAGE_OPTIONS } from '@/store/cartStore'
 
 interface DragDropCalendarProps {
@@ -120,6 +121,38 @@ const DragDropCalendar: React.FC<DragDropCalendarProps> = ({
 
   const { addRoomFromDrop } = useCartStore()
 
+  type AvailabilityClient = Pick<typeof FirebaseAvailabilityService, 'getDailyAvailability'>
+
+  const fetchAvailabilityForMonth = async (service: AvailabilityClient) => {
+    const startOfMonth = new Date(currentMonth.getFullYear(), currentMonth.getMonth(), 1)
+    const endOfMonth = new Date(currentMonth.getFullYear(), currentMonth.getMonth() + 1, 0)
+    const data: Record<string, DailyAvailability> = {}
+
+    const currentDate = new Date(startOfMonth)
+    while (currentDate <= endOfMonth) {
+      const dateStr = currentDate.toISOString().split('T')[0]
+      try {
+        const dayAvailability = await service.getDailyAvailability(dateStr)
+        if (dayAvailability) {
+          data[dateStr] = dayAvailability
+        }
+      } catch (error) {
+        console.warn(`Failed to load availability for ${dateStr}:`, error)
+      }
+      currentDate.setDate(currentDate.getDate() + 1)
+    }
+
+    return data
+  }
+
+  const hasUsableAvailability = (data: Record<string, DailyAvailability>) => {
+    if (Object.keys(data).length === 0) return false
+
+    return Object.values(data).some(day =>
+      Object.values(day.availability || {}).some(typeAvail => typeAvail.availableRooms > 0)
+    )
+  }
+
   // Helper functions (defined before useMemo to avoid hoisting issues)
   const getAvailabilityCount = (availability: DailyAvailability | undefined, type?: RoomType): number => {
     if (!availability) return 0
@@ -157,27 +190,23 @@ const DragDropCalendar: React.FC<DragDropCalendarProps> = ({
     const loadAvailabilityData = async () => {
       setLoading(true)
       try {
-        const startOfMonth = new Date(currentMonth.getFullYear(), currentMonth.getMonth(), 1)
-        const endOfMonth = new Date(currentMonth.getFullYear(), currentMonth.getMonth() + 1, 0)
-        const data: Record<string, DailyAvailability> = {}
+        const primaryData = await fetchAvailabilityForMonth(FirebaseAvailabilityService)
 
-        const currentDate = new Date(startOfMonth)
-        while (currentDate <= endOfMonth) {
-          const dateStr = currentDate.toISOString().split('T')[0]
-          try {
-            const dayAvailability = await AvailabilityService.getDailyAvailability(dateStr)
-            if (dayAvailability) {
-              data[dateStr] = dayAvailability
-            }
-          } catch (error) {
-            console.warn(`Failed to load availability for ${dateStr}:`, error)
-          }
-          currentDate.setDate(currentDate.getDate() + 1)
+        if (hasUsableAvailability(primaryData)) {
+          setAvailabilityData(primaryData)
+        } else {
+          const fallbackData = await fetchAvailabilityForMonth(MockAvailabilityService)
+          setAvailabilityData(fallbackData)
         }
-
-        setAvailabilityData(data)
       } catch (error) {
         console.error('Failed to load availability data:', error)
+        try {
+          const fallbackData = await fetchAvailabilityForMonth(MockAvailabilityService)
+          setAvailabilityData(fallbackData)
+        } catch (mockError) {
+          console.error('Failed to load mock availability data:', mockError)
+          setAvailabilityData({})
+        }
       } finally {
         setLoading(false)
       }


### PR DESCRIPTION
## Summary
- fall back to mock room data on the booking page when live Firebase data is unavailable
- add graceful fallback to mock availability data so the drag-and-drop calendar shows usable availability information

## Testing
- npm run lint *(fails: repository already has numerous legacy lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d2fa34250c833292e220c2c6276fcc