### PR TITLE
refactor: replace booking drag-and-drop with click selection

### DIFF
--- a/src/components/booking/BookingFlow.tsx
+++ b/src/components/booking/BookingFlow.tsx
@@ -203,7 +203,7 @@ const BookingFlow: React.FC<BookingFlowProps> = ({
                 Build Your Perfect Stay
               </h1>
               <p className="text-lg text-lundies-peat max-w-2xl mx-auto">
-                Drag rooms to your preferred dates or browse our selection to create your Highland getaway.
+                Select a room and then choose your check-in and check-out dates to craft your Highland getaway.
               </p>
             </div>
 

--- a/src/components/booking/DragDropCalendar.tsx
+++ b/src/components/booking/DragDropCalendar.tsx
@@ -1,10 +1,6 @@
-// Epic 5: Drag-and-Drop Calendar Component
-// SCHH-013: Drag-and-Drop Room Selection
-
 'use client'
 
-import { useState, useEffect, useMemo } from 'react'
-import { DragDropContext, Droppable, Draggable, DropResult } from 'react-beautiful-dnd'
+import { useState, useEffect, useMemo, useCallback } from 'react'
 import { DailyAvailability, Room, RoomType, PackageType } from '@/types/hotel'
 import { AvailabilityService as FirebaseAvailabilityService } from '@/lib/firebase/hotel-service'
 import { AvailabilityService as MockAvailabilityService } from '@/lib/firebase/hotel-service-mock'
@@ -27,83 +23,82 @@ interface CalendarDay {
   isPeak?: boolean
 }
 
-interface DraggableRoomCardProps {
+interface RoomCardProps {
   room: Room
-  index: number
-  guests: number
+  isSelected: boolean
+  onSelect: () => void
 }
 
-const DraggableRoomCard: React.FC<DraggableRoomCardProps> = ({ room, index, guests }) => {
-  const formatPrice = (priceInPence: number): string => {
-    return `£${(priceInPence / 100).toFixed(2)}`
-  }
+type FeedbackType = 'info' | 'success' | 'error'
 
+const formatCurrency = (priceInPence: number): string => {
+  return `£${(priceInPence / 100).toFixed(2)}`
+}
+
+const formatDisplayDate = (dateString: string) => {
+  const date = new Date(dateString)
+  return date.toLocaleDateString('en-GB', {
+    day: 'numeric',
+    month: 'short'
+  })
+}
+
+const RoomCard: React.FC<RoomCardProps> = ({ room, isSelected, onSelect }) => {
   return (
-    <Draggable draggableId={room.id} index={index}>
-      {(provided, snapshot) => (
-        <div
-          ref={provided.innerRef}
-          {...provided.draggableProps}
-          {...provided.dragHandleProps}
-          className={`
-            rounded-2xl border p-4 transition-all cursor-grab active:cursor-grabbing
-            ${snapshot.isDragging
-              ? 'border-lundies-heather bg-lundies-heather/20 shadow-2xl shadow-lundies-heather/30 scale-105'
-              : 'border-white/10 bg-white/5 hover:bg-white/10'
-            }
-            ${snapshot.isDragging ? 'rotate-3' : ''}
-          `}
-        >
-          <div className="flex items-start justify-between mb-2">
-            <div>
-              <h3 className="text-white font-medium capitalize text-sm">
-                {room.type} Room
-              </h3>
-              <p className="text-lundies-heather text-xs">Room {room.roomNumber}</p>
-            </div>
-            <div className="text-right">
-              <p className="text-white font-semibold text-sm">
-                {formatPrice(room.pricing.basePrice)}
-              </p>
-              <p className="text-lundies-stone text-xs">per night</p>
-            </div>
-          </div>
-
-          <div className="grid grid-cols-2 gap-2 text-xs text-lundies-stone mb-2">
-            <div>Max: {room.maxOccupancy}</div>
-            <div>{room.size}m²</div>
-            <div className="capitalize">{room.view} view</div>
-            <div>Floor {room.floor}</div>
-          </div>
-
-          {/* Room features */}
-          <div className="flex flex-wrap gap-1">
-            {room.features.wifi && (
-              <span className="px-2 py-1 rounded-full bg-lundies-heather/20 text-lundies-heather text-xs">
-                WiFi
-              </span>
-            )}
-            {room.features.balcony && (
-              <span className="px-2 py-1 rounded-full bg-sky-500/20 text-sky-300 text-xs">
-                Balcony
-              </span>
-            )}
-            {room.features.airConditioning && (
-              <span className="px-2 py-1 rounded-full bg-blue-500/20 text-blue-300 text-xs">
-                AC
-              </span>
-            )}
-          </div>
-
-          {/* Drag hint */}
-          {!snapshot.isDragging && (
-            <div className="mt-2 text-center text-xs text-lundies-stone">
-              Drag to calendar
-            </div>
-          )}
+    <button
+      type="button"
+      onClick={onSelect}
+      className={`
+        w-full text-left rounded-2xl border p-4 transition-all
+        ${isSelected
+          ? 'border-lundies-heather bg-lundies-heather/20 shadow-2xl shadow-lundies-heather/30'
+          : 'border-white/10 bg-white/5 hover:bg-white/10'}
+      `}
+    >
+      <div className="flex items-start justify-between mb-2">
+        <div>
+          <h3 className="text-white font-medium capitalize text-sm">
+            {room.type} Room
+          </h3>
+          <p className="text-lundies-heather text-xs">Room {room.roomNumber}</p>
         </div>
-      )}
-    </Draggable>
+        <div className="text-right">
+          <p className="text-white font-semibold text-sm">
+            {formatCurrency(room.pricing.basePrice)}
+          </p>
+          <p className="text-lundies-stone text-xs">per night</p>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-2 text-xs text-lundies-stone mb-2">
+        <div>Max: {room.maxOccupancy}</div>
+        <div>{room.size}m²</div>
+        <div className="capitalize">{room.view} view</div>
+        <div>Floor {room.floor}</div>
+      </div>
+
+      <div className="flex flex-wrap gap-1">
+        {room.features.wifi && (
+          <span className="px-2 py-1 rounded-full bg-lundies-heather/20 text-lundies-heather text-xs">
+            WiFi
+          </span>
+        )}
+        {room.features.balcony && (
+          <span className="px-2 py-1 rounded-full bg-sky-500/20 text-sky-300 text-xs">
+            Balcony
+          </span>
+        )}
+        {room.features.airConditioning && (
+          <span className="px-2 py-1 rounded-full bg-blue-500/20 text-blue-300 text-xs">
+            AC
+          </span>
+        )}
+      </div>
+
+      <div className="mt-2 text-center text-xs text-lundies-stone">
+        {isSelected ? 'Selected' : 'Click to choose this room'}
+      </div>
+    </button>
   )
 }
 
@@ -117,9 +112,15 @@ const DragDropCalendar: React.FC<DragDropCalendarProps> = ({
   const [availabilityData, setAvailabilityData] = useState<Record<string, DailyAvailability>>({})
   const [loading, setLoading] = useState(false)
   const [selectedPackage, setSelectedPackage] = useState<PackageType>('room-only')
-  const [dragOverDate, setDragOverDate] = useState<string | null>(null)
+  const [selectedRoomId, setSelectedRoomId] = useState<string | null>(null)
+  const [hoverDate, setHoverDate] = useState<string | null>(null)
+  const [selectedDates, setSelectedDates] = useState<{ checkIn: string | null; checkOut: string | null }>({
+    checkIn: null,
+    checkOut: null
+  })
+  const [feedback, setFeedback] = useState<{ type: FeedbackType; message: string } | null>(null)
 
-  const { addRoomFromDrop } = useCartStore()
+  const { addItem } = useCartStore()
 
   type AvailabilityClient = Pick<typeof FirebaseAvailabilityService, 'getDailyAvailability'>
 
@@ -153,7 +154,6 @@ const DragDropCalendar: React.FC<DragDropCalendarProps> = ({
     )
   }
 
-  // Helper functions (defined before useMemo to avoid hoisting issues)
   const getAvailabilityCount = (availability: DailyAvailability | undefined, type?: RoomType): number => {
     if (!availability) return 0
 
@@ -185,7 +185,6 @@ const DragDropCalendar: React.FC<DragDropCalendarProps> = ({
     return month >= 5 && month <= 8 // June to September
   }
 
-  // Load availability data for current month
   useEffect(() => {
     const loadAvailabilityData = async () => {
       setLoading(true)
@@ -215,7 +214,6 @@ const DragDropCalendar: React.FC<DragDropCalendarProps> = ({
     loadAvailabilityData()
   }, [currentMonth])
 
-  // Generate calendar days
   const calendarDays = useMemo(() => {
     const year = currentMonth.getFullYear()
     const month = currentMonth.getMonth()
@@ -232,12 +230,15 @@ const DragDropCalendar: React.FC<DragDropCalendarProps> = ({
       const dateString = currentDate.toISOString().split('T')[0]
       const availability = availabilityData[dateString]
       const today = new Date()
+      today.setHours(0, 0, 0, 0)
+      const comparisonDate = new Date(currentDate)
+      comparisonDate.setHours(0, 0, 0, 0)
 
       days.push({
         date: new Date(currentDate),
         dateString,
         isCurrentMonth: currentDate.getMonth() === month,
-        isBlocked: currentDate < today,
+        isBlocked: comparisonDate < today,
         availability: getAvailabilityCount(availability, selectedRoomType),
         price: getPrice(availability, selectedRoomType),
         isPeak: isPeakSeason(currentDate)
@@ -249,45 +250,38 @@ const DragDropCalendar: React.FC<DragDropCalendarProps> = ({
     return days
   }, [currentMonth, availabilityData, selectedRoomType])
 
-  const handleDragEnd = (result: DropResult) => {
-    const { destination, draggableId } = result
-    setDragOverDate(null)
+  const selectedRoom = useMemo(
+    () => availableRooms.find(room => room.id === selectedRoomId) || null,
+    [availableRooms, selectedRoomId]
+  )
 
-    if (!destination) {
-      return
+  const selectionRangeEnd = useMemo(() => {
+    if (!selectedDates.checkIn) return null
+    if (selectedDates.checkOut) return selectedDates.checkOut
+    if (hoverDate && new Date(hoverDate) > new Date(selectedDates.checkIn)) {
+      return hoverDate
     }
+    return null
+  }, [selectedDates, hoverDate])
 
-    const roomId = draggableId
-    const targetDate = destination.droppableId.replace('date-', '')
-    const room = availableRooms.find(r => r.id === roomId)
+  const getDaySelectionState = useCallback(
+    (day: CalendarDay) => {
+      const { dateString } = day
+      const isStart = selectedDates.checkIn === dateString
+      const isEnd = selectedDates.checkOut === dateString
 
-    if (!room) {
-      console.error('Room not found:', roomId)
-      return
-    }
+      let isInRange = false
+      if (selectedDates.checkIn && selectionRangeEnd) {
+        const start = new Date(selectedDates.checkIn)
+        const end = new Date(selectionRangeEnd)
+        const current = new Date(dateString)
+        isInRange = current > start && current < end
+      }
 
-    // Check if the date is valid for booking
-    const targetDateObj = new Date(targetDate)
-    const today = new Date()
-
-    if (targetDateObj < today) {
-      alert('Cannot book rooms for past dates')
-      return
-    }
-
-    // Add room to cart via drag and drop
-    addRoomFromDrop({
-      room,
-      targetDate,
-      packageType: selectedPackage,
-      guests
-    })
-
-    // Call optional callback
-    if (onRoomDrop) {
-      onRoomDrop(roomId, targetDate)
-    }
-  }
+      return { isStart, isEnd, isInRange }
+    },
+    [selectedDates, selectionRangeEnd]
+  )
 
   const navigateMonth = (direction: 'prev' | 'next') => {
     setCurrentMonth(prev => {
@@ -301,211 +295,307 @@ const DragDropCalendar: React.FC<DragDropCalendarProps> = ({
     })
   }
 
-  const formatPrice = (priceInPence: number): string => {
-    return `£${(priceInPence / 100).toFixed(0)}`
+  const resetDateSelection = () => {
+    setSelectedDates({ checkIn: null, checkOut: null })
+    setHoverDate(null)
   }
+
+  const handleRoomSelect = (roomId: string) => {
+    setSelectedRoomId(prev => (prev === roomId ? null : roomId))
+    resetDateSelection()
+    setFeedback(null)
+  }
+
+  const handleDayClick = (day: CalendarDay) => {
+    if (day.isBlocked || !day.isCurrentMonth) {
+      return
+    }
+
+    if (!selectedRoom) {
+      setFeedback({
+        type: 'error',
+        message: 'Select a room before choosing your stay dates.'
+      })
+      return
+    }
+
+    const clickedDate = day.dateString
+
+    if (!selectedDates.checkIn || selectedDates.checkOut) {
+      setSelectedDates({ checkIn: clickedDate, checkOut: null })
+      setFeedback({
+        type: 'info',
+        message: `Check-in set to ${formatDisplayDate(clickedDate)}. Now pick your check-out date.`
+      })
+      return
+    }
+
+    const checkInDate = selectedDates.checkIn
+    if (!checkInDate) {
+      return
+    }
+
+    const checkIn = new Date(checkInDate)
+    const checkOut = new Date(clickedDate)
+
+    if (checkOut <= checkIn) {
+      setSelectedDates({ checkIn: clickedDate, checkOut: null })
+      setFeedback({
+        type: 'info',
+        message: `Check-in updated to ${formatDisplayDate(clickedDate)}. Choose a later date for check-out.`
+      })
+      return
+    }
+
+    const numberOfNights = Math.ceil((checkOut.getTime() - checkIn.getTime()) / (1000 * 3600 * 24))
+    const packageOption = PACKAGE_OPTIONS[selectedPackage]
+    const totalRoomCost = selectedRoom.pricing.basePrice * numberOfNights
+    const totalPackageCost = packageOption.priceAdjustment * numberOfNights
+    const totalCost = totalRoomCost + totalPackageCost
+
+    addItem({
+      room: selectedRoom,
+      checkInDate,
+      checkOutDate: clickedDate,
+      numberOfNights,
+      guests,
+      packageType: selectedPackage,
+      packageOption,
+      roomRate: selectedRoom.pricing.basePrice,
+      packageRate: packageOption.priceAdjustment,
+      totalRoomCost,
+      totalPackageCost,
+      totalCost
+    })
+
+    setSelectedDates({ checkIn: null, checkOut: null })
+    setHoverDate(null)
+    setFeedback({
+      type: 'success',
+      message: `Room ${selectedRoom.roomNumber} added for ${formatDisplayDate(checkInDate)} to ${formatDisplayDate(clickedDate)}.`
+    })
+
+    if (onRoomDrop) {
+      onRoomDrop(selectedRoom.id, checkInDate)
+    }
+  }
+
+  const helperMessage = useMemo(() => {
+    if (feedback) {
+      return feedback
+    }
+
+    if (!selectedRoom) {
+      return {
+        type: 'info' as FeedbackType,
+        message: 'Select a room to begin planning your stay.'
+      }
+    }
+
+    if (!selectedDates.checkIn) {
+      return {
+        type: 'info' as FeedbackType,
+        message: `Choose your check-in date for Room ${selectedRoom.roomNumber}.`
+      }
+    }
+
+    return {
+      type: 'info' as FeedbackType,
+      message: 'Now pick your check-out date to complete your stay.'
+    }
+  }, [feedback, selectedRoom, selectedDates.checkIn])
 
   const monthName = currentMonth.toLocaleDateString('en-GB', {
     month: 'long',
     year: 'numeric'
   })
 
+  const messageStyles: Record<FeedbackType, string> = {
+    info: 'border-white/20 bg-white/5 text-lundies-stone',
+    success: 'border-emerald-400/40 bg-emerald-500/10 text-emerald-100',
+    error: 'border-rose-400/60 bg-rose-500/10 text-rose-100'
+  }
+
   return (
-    <DragDropContext onDragEnd={handleDragEnd}>
-      <div className="rounded-3xl border border-white/10 bg-lundies-charcoal/80 backdrop-blur-sm p-6">
-        {/* Header */}
-        <div className="flex items-center justify-between mb-6">
-          <div>
-            <h2 className="text-2xl font-semibold text-white">
-              Drag & Drop Booking
-            </h2>
-            <p className="text-lundies-stone">
-              Drag rooms to your preferred dates
-            </p>
-          </div>
-
-          {/* Package Selection */}
-          <div className="text-right">
-            <label className="block text-sm text-lundies-stone mb-2">Package Type</label>
-            <select
-              value={selectedPackage}
-              onChange={(e) => setSelectedPackage(e.target.value as PackageType)}
-              className="rounded-xl border border-white/20 bg-black/30 px-3 py-2 text-white text-sm focus:outline-none focus:ring-2 focus:ring-lundies-heather"
-            >
-              {Object.entries(PACKAGE_OPTIONS).map(([key, option]) => (
-                <option key={key} value={key}>
-                  {option.name}
-                </option>
-              ))}
-            </select>
-          </div>
+    <div className="rounded-3xl border border-white/10 bg-lundies-charcoal/80 backdrop-blur-sm p-6">
+      <div className="flex items-center justify-between mb-6 flex-col gap-4 lg:flex-row">
+        <div>
+          <h2 className="text-2xl font-semibold text-white">
+            Room &amp; Date Selection
+          </h2>
+          <p className="text-lundies-stone">
+            Choose a room and then click your desired check-in and check-out dates.
+          </p>
         </div>
 
-        <div className="grid lg:grid-cols-3 gap-6">
-          {/* Available Rooms */}
-          <div className="lg:col-span-1">
-            <h3 className="text-lg font-medium text-white mb-4">Available Rooms</h3>
-
-            <Droppable droppableId="available-rooms" isDropDisabled={false} isCombineEnabled={false} ignoreContainerClipping={false}>
-              {(provided, snapshot) => (
-                <div
-                  ref={provided.innerRef}
-                  {...provided.droppableProps}
-                  className={`
-                    space-y-3 min-h-[200px] p-4 rounded-2xl border-2 border-dashed transition-colors
-                    ${snapshot.isDraggingOver
-                      ? 'border-lundies-heather bg-lundies-heather/10'
-                      : 'border-white/20'
-                    }
-                  `}
-                >
-                  {availableRooms.length === 0 ? (
-                    <div className="text-center py-8">
-                      <p className="text-lundies-stone">No rooms available for selected criteria</p>
-                    </div>
-                  ) : (
-                    availableRooms.map((room, index) => (
-                      <DraggableRoomCard
-                        key={room.id}
-                        room={room}
-                        index={index}
-                        guests={guests}
-                      />
-                    ))
-                  )}
-                  {provided.placeholder}
-                </div>
-              )}
-            </Droppable>
-          </div>
-
-          {/* Calendar */}
-          <div className="lg:col-span-2">
-            {/* Calendar Header */}
-            <div className="flex items-center justify-between mb-4">
-              <h3 className="text-lg font-medium text-white">{monthName}</h3>
-              <div className="flex gap-2">
-                <button
-                  onClick={() => navigateMonth('prev')}
-                  className="w-8 h-8 rounded-full bg-white/10 text-white hover:bg-white/20 transition-colors flex items-center justify-center"
-                >
-                  ‹
-                </button>
-                <button
-                  onClick={() => navigateMonth('next')}
-                  className="w-8 h-8 rounded-full bg-white/10 text-white hover:bg-white/20 transition-colors flex items-center justify-center"
-                >
-                  ›
-                </button>
-              </div>
-            </div>
-
-            {/* Day Headers */}
-            <div className="grid grid-cols-7 gap-1 mb-2">
-              {['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'].map(day => (
-                <div key={`header-${day}`} className="text-center text-xs font-medium text-lundies-stone py-2">
-                  {day}
-                </div>
-              ))}
-            </div>
-
-            {/* Calendar Grid */}
-            <div className="grid grid-cols-7 gap-1">
-              {calendarDays.map((day, index) => {
-                const isDropTarget = `date-${day.dateString}` === dragOverDate
-
-                const isDropDisabled = day.isBlocked || !day.isCurrentMonth
-
-                return (
-                  <Droppable
-                    key={day.dateString}
-                    droppableId={`date-${day.dateString}`}
-                    isDropDisabled={isDropDisabled}
-                    isCombineEnabled={false}
-                    ignoreContainerClipping={true}
-                  >
-                    {(provided, snapshot) => (
-                      <div
-                        ref={provided.innerRef}
-                        {...provided.droppableProps}
-                        className={`
-                          relative aspect-square p-1 text-xs transition-all
-                          rounded-lg border-2 border-dashed
-                          ${day.isBlocked
-                            ? 'border-transparent bg-lundies-charcoal/50 text-lundies-stone cursor-not-allowed'
-                            : !day.isCurrentMonth
-                              ? 'border-transparent bg-lundies-charcoal/30 text-lundies-stone cursor-not-allowed'
-                              : snapshot.isDraggingOver
-                                ? 'border-lundies-heather bg-lundies-heather/20 scale-105 cursor-pointer'
-                                : 'border-white/10 bg-white/5 text-white hover:bg-white/10 cursor-pointer'
-                          }
-                          ${day.isPeak ? 'ring-1 ring-orange-400/30' : ''}
-                        `}
-                        onDragEnter={() => setDragOverDate(`date-${day.dateString}`)}
-                        onDragLeave={() => setDragOverDate(null)}
-                      >
-                        <div className="flex flex-col h-full">
-                          <div className="text-center mb-1">
-                            {day.date.getDate()}
-                          </div>
-
-                          {day.isCurrentMonth && !day.isBlocked && (
-                            <>
-                              {day.availability !== undefined && (
-                                <div className="text-center text-xs text-lundies-heather">
-                                  {day.availability} avail
-                                </div>
-                              )}
-                              {day.price && (
-                                <div className="text-center text-xs text-lundies-stone">
-                                  {formatPrice(day.price)}
-                                </div>
-                              )}
-                            </>
-                          )}
-
-                          {snapshot.isDraggingOver && (
-                            <div className="absolute inset-0 flex items-center justify-center">
-                              <div className="w-6 h-6 rounded-full bg-lundies-heather flex items-center justify-center">
-                                <span className="text-lundies-charcoal text-xs font-bold">+</span>
-                              </div>
-                            </div>
-                          )}
-                        </div>
-                        {provided.placeholder}
-                      </div>
-                    )}
-                  </Droppable>
-                )
-              })}
-            </div>
-
-            {/* Legend */}
-            <div className="flex flex-wrap gap-4 mt-4 text-xs">
-              <div className="flex items-center gap-2">
-                <div className="w-3 h-3 rounded bg-lundies-heather/20 border border-lundies-heather"></div>
-                <span className="text-lundies-stone">Available</span>
-              </div>
-              <div className="flex items-center gap-2">
-                <div className="w-3 h-3 rounded bg-lundies-charcoal border border-lundies-stone"></div>
-                <span className="text-lundies-stone">Blocked</span>
-              </div>
-              <div className="flex items-center gap-2">
-                <div className="w-3 h-3 rounded bg-orange-400/20 border border-orange-400"></div>
-                <span className="text-lundies-stone">Peak Season</span>
-              </div>
-            </div>
-          </div>
+        <div className="text-right w-full lg:w-auto">
+          <label className="block text-sm text-lundies-stone mb-2">Package Type</label>
+          <select
+            value={selectedPackage}
+            onChange={(e) => setSelectedPackage(e.target.value as PackageType)}
+            className="w-full lg:w-auto rounded-xl border border-white/20 bg-black/30 px-3 py-2 text-white text-sm focus:outline-none focus:ring-2 focus:ring-lundies-heather"
+          >
+            {Object.entries(PACKAGE_OPTIONS).map(([key, option]) => (
+              <option key={key} value={key}>
+                {option.name}
+              </option>
+            ))}
+          </select>
         </div>
-
-        {loading && (
-          <div className="text-center py-4">
-            <div className="inline-block animate-spin rounded-full h-6 w-6 border-b-2 border-lundies-heather"></div>
-            <p className="text-lundies-stone mt-2">Loading availability...</p>
-          </div>
-        )}
       </div>
-    </DragDropContext>
+
+      <div className={`mb-6 rounded-2xl border px-4 py-3 text-sm ${messageStyles[helperMessage.type]}`}>
+        <div className="flex items-start justify-between gap-4">
+          <span>{helperMessage.message}</span>
+          {selectedDates.checkIn && (
+            <button
+              type="button"
+              onClick={resetDateSelection}
+              className="text-xs uppercase tracking-[0.2em] text-lundies-heather hover:text-lundies-heather/80"
+            >
+              Clear dates
+            </button>
+          )}
+        </div>
+      </div>
+
+      <div className="grid lg:grid-cols-3 gap-6">
+        <div className="lg:col-span-1">
+          <h3 className="text-lg font-medium text-white mb-4">Available Rooms</h3>
+          <div className="space-y-3 min-h-[200px] p-4 rounded-2xl border-2 border-dashed border-white/20">
+            {availableRooms.length === 0 ? (
+              <div className="text-center py-8">
+                <p className="text-lundies-stone">No rooms available for selected criteria</p>
+              </div>
+            ) : (
+              availableRooms.map((room) => (
+                <RoomCard
+                  key={room.id}
+                  room={room}
+                  isSelected={selectedRoomId === room.id}
+                  onSelect={() => handleRoomSelect(room.id)}
+                />
+              ))
+            )}
+          </div>
+        </div>
+
+        <div className="lg:col-span-2">
+          <div className="flex items-center justify-between mb-4">
+            <h3 className="text-lg font-medium text-white">{monthName}</h3>
+            <div className="flex gap-2">
+              <button
+                onClick={() => navigateMonth('prev')}
+                className="w-8 h-8 rounded-full bg-white/10 text-white hover:bg-white/20 transition-colors flex items-center justify-center"
+                aria-label="Previous month"
+              >
+                ‹
+              </button>
+              <button
+                onClick={() => navigateMonth('next')}
+                className="w-8 h-8 rounded-full bg-white/10 text-white hover:bg-white/20 transition-colors flex items-center justify-center"
+                aria-label="Next month"
+              >
+                ›
+              </button>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-7 gap-1 mb-2">
+            {['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'].map(day => (
+              <div key={`header-${day}`} className="text-center text-xs font-medium text-lundies-stone py-2">
+                {day}
+              </div>
+            ))}
+          </div>
+
+          <div className="grid grid-cols-7 gap-1">
+            {calendarDays.map((day) => {
+              const { isStart, isEnd, isInRange } = getDaySelectionState(day)
+              const isDisabled = day.isBlocked || !day.isCurrentMonth
+              const classes = [
+                'relative aspect-square p-1 text-xs transition-all rounded-lg border-2',
+                day.isPeak ? 'ring-1 ring-orange-400/30' : '',
+                isDisabled
+                  ? 'border-transparent bg-lundies-charcoal/50 text-lundies-stone cursor-not-allowed'
+                  : 'border-white/10 bg-white/5 text-white hover:bg-white/10 cursor-pointer'
+              ]
+
+              if (isStart || isEnd) {
+                classes.push('border-lundies-heather bg-lundies-heather/30 text-white')
+              } else if (isInRange) {
+                classes.push('border-lundies-heather/40 bg-lundies-heather/10 text-white')
+              }
+
+              return (
+                <div
+                  key={day.dateString}
+                  className={classes.filter(Boolean).join(' ')}
+                  onClick={() => handleDayClick(day)}
+                  onMouseEnter={() => {
+                    if (!isDisabled) {
+                      setHoverDate(day.dateString)
+                    }
+                  }}
+                  onMouseLeave={() => setHoverDate(null)}
+                  role="button"
+                  tabIndex={isDisabled ? -1 : 0}
+                  onKeyDown={(event) => {
+                    if (!isDisabled && (event.key === 'Enter' || event.key === ' ')) {
+                      event.preventDefault()
+                      handleDayClick(day)
+                    }
+                  }}
+                >
+                  <div className="flex flex-col h-full">
+                    <div className="text-center mb-1">
+                      {day.date.getDate()}
+                    </div>
+
+                    {day.isCurrentMonth && !day.isBlocked && (
+                      <>
+                        {day.availability !== undefined && (
+                          <div className="text-center text-xs text-lundies-heather">
+                            {day.availability} avail
+                          </div>
+                        )}
+                        {day.price && (
+                          <div className="text-center text-xs text-lundies-stone">
+                            {formatCurrency(day.price)}
+                          </div>
+                        )}
+                      </>
+                    )}
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+
+          <div className="flex flex-wrap gap-4 mt-4 text-xs">
+            <div className="flex items-center gap-2">
+              <div className="w-3 h-3 rounded bg-lundies-heather/20 border border-lundies-heather"></div>
+              <span className="text-lundies-stone">Selected stay</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <div className="w-3 h-3 rounded bg-lundies-charcoal border border-lundies-stone"></div>
+              <span className="text-lundies-stone">Unavailable</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <div className="w-3 h-3 rounded bg-orange-400/20 border border-orange-400"></div>
+              <span className="text-lundies-stone">Peak Season</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {loading && (
+        <div className="text-center py-4">
+          <div className="inline-block animate-spin rounded-full h-6 w-6 border-b-2 border-lundies-heather"></div>
+          <p className="text-lundies-stone mt-2">Loading availability...</p>
+        </div>
+      )}
+    </div>
   )
 }
 

--- a/tests/booking-page-simple.spec.ts
+++ b/tests/booking-page-simple.spec.ts
@@ -36,7 +36,7 @@ test.describe('Simple Booking Page Test', () => {
     // Check for specific Epic 5 components
     const hasBookingComponents = bodyContent?.includes('Build Your Perfect Stay') ||
                                 bodyContent?.includes('Access Required') ||
-                                bodyContent?.includes('Drag') ||
+                                bodyContent?.includes('Room & Date Selection') ||
                                 bodyContent?.includes('booking');
 
     if (hasBookingComponents) {

--- a/tests/epic5-booking-flow.spec.ts
+++ b/tests/epic5-booking-flow.spec.ts
@@ -1,5 +1,5 @@
 // Epic 5: Booking Flow Implementation Tests
-// SCHH-013: Drag-and-Drop Room Selection
+// SCHH-013: Room and Calendar Selection
 // SCHH-014: Multi-Room Shopping Cart
 // SCHH-015: Guest Information Form
 // SCHH-016: Package Selection Interface
@@ -26,7 +26,7 @@ test.describe('Epic 5: Booking Flow Implementation', () => {
     await page.waitForLoadState('networkidle')
   })
 
-  test('SCHH-013: Drag-and-Drop Room Selection - Navigation and Components', async ({ page }) => {
+  test('SCHH-013: Room Selection - Navigation and Components', async ({ page }) => {
     // Navigate to booking page
     await page.click('text=Book Now')
     await page.waitForLoadState('networkidle')
@@ -34,9 +34,9 @@ test.describe('Epic 5: Booking Flow Implementation', () => {
     // Check that we're on the booking page
     expect(page.url()).toContain('/booking')
 
-    // Verify drag-and-drop calendar is present
-    await expect(page.locator('text=Drag & Drop Booking')).toBeVisible()
-    await expect(page.locator('text=Drag rooms to your preferred dates')).toBeVisible()
+    // Verify room and calendar selection interface is present
+    await expect(page.locator('text=Room & Date Selection')).toBeVisible()
+    await expect(page.locator('text=Choose a room and then click your desired check-in and check-out dates.')).toBeVisible()
 
     // Check for package type selector
     await expect(page.locator('select')).toBeVisible()
@@ -90,7 +90,7 @@ test.describe('Epic 5: Booking Flow Implementation', () => {
     await page.goto('/booking')
     await page.waitForLoadState('networkidle')
 
-    // Check for package selection in the drag-drop calendar
+    // Check for package selection in the booking calendar
     await expect(page.locator('select')).toBeVisible()
 
     // Verify package options exist
@@ -115,7 +115,7 @@ test.describe('Epic 5: Booking Flow Implementation', () => {
 
     // Check main booking flow components
     await expect(page.locator('text=Build Your Perfect Stay')).toBeVisible()
-    await expect(page.locator('text=Drag & Drop Booking')).toBeVisible()
+    await expect(page.locator('text=Room & Date Selection')).toBeVisible()
 
     // Test rooms page integration
     await page.goto('/rooms')
@@ -175,7 +175,7 @@ test.describe('Epic 5: Booking Flow Implementation', () => {
     await expect(page.locator('text=Build Your Perfect Stay')).toBeVisible()
 
     // Check that the main booking interface is functional
-    await expect(page.locator('text=Drag & Drop Booking')).toBeVisible()
+    await expect(page.locator('text=Room & Date Selection')).toBeVisible()
   })
 
   test('Mobile Responsiveness - Basic Layout', async ({ page }) => {
@@ -198,11 +198,11 @@ test.describe('Epic 5: Booking Flow Implementation', () => {
   test('Epic 5 Integration - All Components Accessible', async ({ page }) => {
     console.log('Testing Epic 5: Booking Flow Implementation')
 
-    // Test SCHH-013: Drag-and-Drop Room Selection
+    // Test SCHH-013: Room and Calendar Selection
     await page.goto('/booking')
     await page.waitForLoadState('networkidle')
-    await expect(page.locator('text=Drag & Drop Booking')).toBeVisible()
-    console.log('✓ SCHH-013: Drag-and-Drop components present')
+    await expect(page.locator('text=Room & Date Selection')).toBeVisible()
+    console.log('✓ SCHH-013: Room selection components present')
 
     // Test SCHH-014: Multi-Room Shopping Cart
     await page.goto('/rooms')

--- a/tests/epic5-final-verification.spec.ts
+++ b/tests/epic5-final-verification.spec.ts
@@ -53,13 +53,13 @@ test.describe('Epic 5: Final Implementation Verification', () => {
     // ===== EPIC 5 COMPONENT VERIFICATION =====
     console.log('\n3️⃣ EPIC 5 COMPONENT VERIFICATION');
 
-    // SCHH-013: Drag-and-Drop Room Selection
-    const hasDragDrop = bookingContent?.includes('Drag') ||
-                       bookingContent?.includes('Drop') ||
-                       bookingContent?.includes('Perfect Stay') ||
-                       bookingContent?.includes('Available Rooms');
+    // SCHH-013: Room and Calendar Selection
+    const hasRoomSelection = bookingContent?.includes('Room & Date Selection') ||
+                             bookingContent?.includes('Choose a room and then click your desired check-in and check-out dates.') ||
+                             bookingContent?.includes('Perfect Stay') ||
+                             bookingContent?.includes('Available Rooms');
 
-    console.log(`✅ SCHH-013 Drag-and-Drop Room Selection: ${hasDragDrop ? 'DETECTED' : 'NOT FOUND'}`);
+    console.log(`✅ SCHH-013 Room and Calendar Selection: ${hasRoomSelection ? 'DETECTED' : 'NOT FOUND'}`);
 
     // SCHH-014: Shopping Cart
     const hasCart = bookingContent?.includes('Cart') ||
@@ -129,7 +129,7 @@ test.describe('Epic 5: Final Implementation Verification', () => {
     console.log('=================================');
     console.log('');
     console.log('✅ PRIMARY OBJECTIVE: Firebase Index Error - RESOLVED');
-    console.log('✅ SCHH-013: Drag-and-Drop Room Selection - IMPLEMENTED');
+    console.log('✅ SCHH-013: Room and Calendar Selection - IMPLEMENTED');
     console.log('✅ SCHH-014: Multi-Room Shopping Cart - IMPLEMENTED');
     console.log('✅ SCHH-015: Guest Information Forms - IMPLEMENTED');
     console.log('✅ SCHH-016: Package Selection Interface - IMPLEMENTED');
@@ -144,12 +144,12 @@ test.describe('Epic 5: Final Implementation Verification', () => {
     console.log('   • SCHH-016: 3 points ✅');
     console.log('');
     console.log('🚀 TECHNICAL ACHIEVEMENTS:');
-    console.log('   • React-beautiful-dnd integration');
+    console.log('   • Interactive calendar selection');
     console.log('   • Zustand state management with persistence');
     console.log('   • React Hook Form validation');
     console.log('   • Firebase real-time integration');
     console.log('   • Progressive booking flow orchestration');
-    console.log('   • Mobile-responsive drag-and-drop');
+    console.log('   • Mobile-responsive calendar experience');
     console.log('');
     console.log('✨ Epic 5 implementation is COMPLETE and FUNCTIONAL');
   });

--- a/tests/epic5-manual-test.spec.ts
+++ b/tests/epic5-manual-test.spec.ts
@@ -48,15 +48,15 @@ test.describe('Epic 5: Manual Authentication and Testing', () => {
     console.log('Step 5: Verify Epic 5 components');
     const bookingContent = await page.textContent('body');
 
-    // Check for SCHH-013: Drag-and-Drop Room Selection
-    const hasDragDrop = bookingContent?.includes('Drag') ||
-                       bookingContent?.includes('Drop') ||
-                       bookingContent?.includes('Build Your Perfect Stay');
+    // Check for SCHH-013: Room and Calendar Selection
+    const hasRoomSelection = bookingContent?.includes('Room & Date Selection') ||
+                             bookingContent?.includes('Choose a room and then click your desired check-in and check-out dates.') ||
+                             bookingContent?.includes('Build Your Perfect Stay');
 
-    if (hasDragDrop) {
-      console.log('✅ SCHH-013: Drag-and-Drop components detected');
+    if (hasRoomSelection) {
+      console.log('✅ SCHH-013: Room selection components detected');
     } else {
-      console.log('❌ SCHH-013: Drag-and-Drop components not found');
+      console.log('❌ SCHH-013: Room selection components not found');
     }
 
     // Check for SCHH-014: Shopping Cart

--- a/tests/epic5-verification.spec.ts
+++ b/tests/epic5-verification.spec.ts
@@ -69,12 +69,12 @@ test.describe('Epic 5: Booking Flow Verification', () => {
     console.log('Epic 5: Booking Flow Implementation - Summary')
     console.log('=========================================')
 
-    // SCHH-013: Drag-and-Drop Room Selection (13 points)
-    console.log('✓ SCHH-013: Drag-and-Drop Room Selection')
-    console.log('  - DragDropCalendar component created')
-    console.log('  - react-beautiful-dnd integration added')
+    // SCHH-013: Room and Calendar Selection (13 points)
+    console.log('✓ SCHH-013: Room and Calendar Selection')
+    console.log('  - Room selection calendar component created')
+    console.log('  - Click-to-select date range interactions added')
     console.log('  - Visual feedback and mobile support included')
-    console.log('  - Calendar drop zones implemented')
+    console.log('  - Availability-aware calendar presentation')
 
     // SCHH-014: Multi-Room Shopping Cart (8 points)
     console.log('✓ SCHH-014: Multi-Room Shopping Cart')
@@ -114,7 +114,7 @@ test.describe('Epic 5: Booking Flow Verification', () => {
 test.describe('Epic 5: Technical Implementation', () => {
   test('Dependencies and Architecture', async ({ page }) => {
     console.log('Epic 5 Technical Implementation:')
-    console.log('- react-beautiful-dnd: Drag-and-drop functionality')
+    console.log('- Interactive booking calendar with click-to-select functionality')
     console.log('- react-hook-form: Form management and validation')
     console.log('- zustand: Cart state management with persistence')
     console.log('- Firebase integration: Booking creation and data')


### PR DESCRIPTION
## Summary
- replace the drag-and-drop booking calendar with a click-to-select room and date experience that adds stays directly to the cart
- update booking flow copy to describe the new interaction and keep helper messaging in sync
- refresh Epic 5 Playwright helper specs so they assert the new room/date selection wording instead of drag-and-drop language

## Testing
- `npm run lint` *(fails: existing repository lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d31e7c4de483328e3bc89a8f9f09a2