### PR TITLE
Align admin restaurant and room imagery pages with lundies palette

### DIFF
--- a/src/app/admin/restaurant/page.tsx
+++ b/src/app/admin/restaurant/page.tsx
@@ -32,43 +32,43 @@ const zoneBackgrounds: ZoneBackground[] = [
   {
     zone: 'window',
     style: { left: '0%', top: '0%', width: '42%', height: '48%' },
-    className: 'bg-sky-200/30 dark:bg-sky-900/30 border-sky-400/60',
+    className: 'bg-lundies-heather/15 border-lundies-heather/50',
   },
   {
     zone: 'main_dining',
     style: { left: '38%', top: '6%', width: '54%', height: '56%' },
-    className: 'bg-amber-200/30 dark:bg-amber-900/30 border-amber-400/60',
+    className: 'bg-lundies-sand/20 border-lundies-sand/60',
   },
   {
     zone: 'private',
     style: { left: '4%', top: '52%', width: '34%', height: '40%' },
-    className: 'bg-rose-200/30 dark:bg-rose-900/30 border-rose-400/60',
+    className: 'bg-lundies-peat/15 border-lundies-peat/50',
   },
   {
     zone: 'terrace',
     style: { left: '38%', top: '60%', width: '34%', height: '32%' },
-    className: 'bg-emerald-200/30 dark:bg-emerald-900/30 border-emerald-400/60',
+    className: 'bg-lundies-heather/20 border-lundies-heather/50',
   },
   {
     zone: 'chef_counter',
     style: { left: '72%', top: '58%', width: '24%', height: '28%' },
-    className: 'bg-indigo-200/30 dark:bg-indigo-900/30 border-indigo-400/60',
+    className: 'bg-lundies-stone/30 border-lundies-stone/60',
   },
 ]
 
 const zoneBadgeStyles: Record<TableZone, string> = {
-  main_dining: 'bg-amber-100 text-amber-700 dark:bg-amber-900/60 dark:text-amber-200',
-  window: 'bg-sky-100 text-sky-700 dark:bg-sky-900/60 dark:text-sky-200',
-  private: 'bg-rose-100 text-rose-700 dark:bg-rose-900/60 dark:text-rose-200',
-  terrace: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/60 dark:text-emerald-200',
-  chef_counter: 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/60 dark:text-indigo-200',
+  main_dining: 'bg-lundies-sand/30 text-lundies-sand',
+  window: 'bg-lundies-heather/30 text-lundies-heather',
+  private: 'bg-lundies-peat/25 text-lundies-peat',
+  terrace: 'bg-lundies-heather/25 text-lundies-heather',
+  chef_counter: 'bg-lundies-stone/40 text-lundies-stone',
 }
 
 const tableStatusStyles: Record<RestaurantTable['status'], string> = {
-  available: 'border-emerald-500/70 bg-white/80 dark:bg-slate-900/80',
-  held: 'border-amber-500/70 bg-amber-50/80 dark:bg-amber-900/40',
-  reserved: 'border-rose-500/70 bg-rose-50/80 dark:bg-rose-900/40',
-  maintenance: 'border-slate-400/70 bg-slate-100/70 dark:bg-slate-800/60',
+  available: 'border-lundies-heather bg-lundies-heather/20 text-lundies-charcoal',
+  held: 'border-lundies-sand bg-lundies-sand/20 text-lundies-sand',
+  reserved: 'border-lundies-peat bg-lundies-peat/20 text-lundies-peat',
+  maintenance: 'border-lundies-stone bg-lundies-stone/30 text-lundies-stone',
 }
 
 function normaliseCapacity(capacity: RestaurantTable['capacity']): RestaurantTable['capacity'] {
@@ -301,13 +301,13 @@ export default function RestaurantManagementStudio() {
   }
 
   return (
-    <div className="min-h-screen bg-slate-100 py-10 dark:bg-slate-950">
+    <div className="min-h-screen bg-lundies-linen/80 py-10">
       <div className="mx-auto flex max-w-7xl flex-col gap-10 px-6">
-        <header className="flex flex-col gap-4 rounded-2xl bg-white p-8 shadow-sm ring-1 ring-slate-900/5 dark:bg-slate-900 dark:ring-white/10">
+        <header className="flex flex-col gap-4 rounded-3xl border border-lundies-stone/60 bg-white/95 p-8 shadow-lg shadow-lundies-stone/30">
           <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
             <div>
-              <p className="text-sm uppercase tracking-wider text-slate-500 dark:text-slate-400">Restaurant Module</p>
-              <h1 className="text-3xl font-semibold text-slate-900 dark:text-white">
+              <p className="text-sm uppercase tracking-wider text-lundies-peat">Restaurant Module</p>
+              <h1 className="text-3xl font-semibold text-lundies-charcoal">
                 Table Management Studio
               </h1>
             </div>
@@ -315,59 +315,62 @@ export default function RestaurantManagementStudio() {
               <button
                 type="button"
                 onClick={resetLayout}
-                className="rounded-lg border border-slate-300 px-4 py-2 text-sm font-medium text-slate-600 transition hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+                className="rounded-lg border border-lundies-stone/60 px-4 py-2 text-sm font-medium text-lundies-peat transition hover:border-lundies-heather hover:bg-white/70 hover:text-lundies-heather"
               >
                 Reset to Defaults
               </button>
               <button
                 type="button"
                 onClick={addServicePeriod}
-                className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-emerald-500"
+                className="rounded-lg bg-lundies-heather px-4 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-lundies-heather/90"
               >
                 Add Service Period
               </button>
             </div>
           </div>
-          <p className="max-w-3xl text-sm text-slate-600 dark:text-slate-300">
+          <p className="max-w-3xl text-sm text-lundies-peat">
             Drag tables to rearrange the floor plan, configure capacity rules, and map service periods to guest-facing
             experiences. Every change syncs with live availability and the guest table selector.
           </p>
         </header>
 
         <main className="grid gap-8 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,0.8fr)]">
-          <section>
-            <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+            <section>
+              <div className="rounded-3xl border border-lundies-stone/60 bg-white/95 p-6 shadow-lg shadow-lundies-stone/30">
               <div className="mb-4 flex items-center justify-between">
                 <div>
-                  <h2 className="text-xl font-semibold text-slate-900 dark:text-white">Floor Plan Editor</h2>
-                  <p className="text-sm text-slate-500 dark:text-slate-400">
+                  <h2 className="text-xl font-semibold text-lundies-charcoal">Floor Plan Editor</h2>
+                  <p className="text-sm text-lundies-peat">
                     Visualise the dining room, highlight zones, and drag tables into new positions.
                   </p>
                 </div>
-                <div className="flex gap-3 text-xs text-slate-500 dark:text-slate-400">
+                <div className="flex flex-wrap gap-3 text-xs text-lundies-peat">
                   <span className="flex items-center gap-1">
-                    <span className="h-3 w-3 rounded-full bg-emerald-500" /> Available
+                    <span className="h-3 w-3 rounded-full bg-lundies-heather" /> Available
                   </span>
                   <span className="flex items-center gap-1">
-                    <span className="h-3 w-3 rounded-full bg-amber-500" /> Held
+                    <span className="h-3 w-3 rounded-full bg-lundies-sand" /> Held
                   </span>
                   <span className="flex items-center gap-1">
-                    <span className="h-3 w-3 rounded-full bg-rose-500" /> Reserved
+                    <span className="h-3 w-3 rounded-full bg-lundies-peat" /> Reserved
+                  </span>
+                  <span className="flex items-center gap-1">
+                    <span className="h-3 w-3 rounded-full bg-lundies-stone" /> Maintenance
                   </span>
                 </div>
               </div>
 
-              <div
-                ref={floorplanRef}
-                className="relative mx-auto flex max-w-full items-center justify-center overflow-hidden rounded-2xl border border-slate-200 bg-slate-50 shadow-inner dark:border-slate-800 dark:bg-slate-950"
-                style={{
-                  width: FLOORPLAN_WIDTH,
-                  height: FLOORPLAN_HEIGHT,
-                  backgroundImage:
-                    'linear-gradient(to right, rgba(148, 163, 184, 0.15) 1px, transparent 1px), linear-gradient(to bottom, rgba(148, 163, 184, 0.15) 1px, transparent 1px)',
-                  backgroundSize: '40px 40px',
-                }}
-              >
+                <div
+                  ref={floorplanRef}
+                  className="relative mx-auto flex max-w-full items-center justify-center overflow-hidden rounded-3xl border border-lundies-stone/60 bg-lundies-linen/70 shadow-inner"
+                  style={{
+                    width: FLOORPLAN_WIDTH,
+                    height: FLOORPLAN_HEIGHT,
+                    backgroundImage:
+                      'linear-gradient(to right, rgba(214, 206, 195, 0.2) 1px, transparent 1px), linear-gradient(to bottom, rgba(214, 206, 195, 0.2) 1px, transparent 1px)',
+                    backgroundSize: '40px 40px',
+                  }}
+                >
                 <div className="absolute inset-0">
                   {zoneBackgrounds.map((item) => (
                     <div
@@ -375,7 +378,7 @@ export default function RestaurantManagementStudio() {
                       className={`absolute rounded-xl border ${item.className}`}
                       style={item.style}
                     >
-                      <span className="absolute left-2 top-2 rounded-full bg-white/90 px-2 py-1 text-xs font-medium text-slate-600 shadow-sm dark:bg-slate-900/80 dark:text-slate-200">
+                      <span className="absolute left-2 top-2 rounded-full border border-lundies-stone/50 bg-white/90 px-2 py-1 text-xs font-medium text-lundies-peat shadow-sm">
                         {formatZoneLabel(item.zone)}
                       </span>
                     </div>
@@ -413,12 +416,12 @@ export default function RestaurantManagementStudio() {
                         height: TABLE_SIZE,
                         transform: `translate(${table.position.x}px, ${table.position.y}px)`,
                       }}
-                      className={`absolute flex flex-col items-center justify-center rounded-xl border-2 px-2 text-center text-sm font-semibold text-slate-700 shadow-md transition focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 dark:text-slate-100 ${tableStatusStyles[table.status]} ${
-                        isSelected ? 'ring-2 ring-emerald-500' : 'ring-0'
+                      className={`absolute flex flex-col items-center justify-center rounded-xl border-2 px-2 text-center text-sm font-semibold text-lundies-charcoal shadow-md transition focus:outline-none focus-visible:ring-2 focus-visible:ring-lundies-heather ${tableStatusStyles[table.status]} ${
+                        isSelected ? 'ring-2 ring-lundies-heather' : 'ring-0'
                       } ${draggingId === table.id ? 'cursor-grabbing' : 'cursor-grab'}`}
                     >
                       <span className="text-base font-bold">{table.label}</span>
-                      <span className="text-xs font-medium text-slate-500 dark:text-slate-400">
+                      <span className="text-xs font-medium text-lundies-peat">
                         {table.capacity.default} seats
                       </span>
                       <span
@@ -434,17 +437,17 @@ export default function RestaurantManagementStudio() {
           </section>
 
           <aside className="space-y-6">
-            <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
-              <h2 className="text-xl font-semibold text-slate-900 dark:text-white">Table Configuration</h2>
+              <div className="rounded-3xl border border-lundies-stone/60 bg-white/95 p-6 shadow-lg shadow-lundies-stone/30">
+              <h2 className="text-xl font-semibold text-lundies-charcoal">Table Configuration</h2>
               {selectedTable ? (
-                <div className="mt-4 space-y-6 text-sm text-slate-600 dark:text-slate-300">
+                <div className="mt-4 space-y-6 text-sm text-lundies-peat">
                   <div className="grid gap-3">
-                    <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                    <label className="text-xs font-semibold uppercase tracking-wide text-lundies-peat">
                       Table Label
                     </label>
                     <div className="flex items-center gap-2">
-                      <span className="text-lg font-semibold text-slate-900 dark:text-white">{selectedTable.label}</span>
-                      <span className="rounded-full border border-slate-300 px-2 py-0.5 text-xs text-slate-500 dark:border-slate-700 dark:text-slate-400">
+                      <span className="text-lg font-semibold text-lundies-charcoal">{selectedTable.label}</span>
+                      <span className="rounded-full border border-lundies-stone/60 px-2 py-0.5 text-xs text-lundies-peat">
                         ID: {selectedTable.id}
                       </span>
                     </div>
@@ -453,7 +456,7 @@ export default function RestaurantManagementStudio() {
                   <div className="grid gap-4 md:grid-cols-3">
                     {(['min', 'default', 'max'] as const).map((key) => (
                       <label key={key} className="flex flex-col gap-1">
-                        <span className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                        <span className="text-xs font-semibold uppercase tracking-wide text-lundies-peat">
                           {key === 'min' && 'Minimum'}
                           {key === 'default' && 'Default'}
                           {key === 'max' && 'Maximum'}
@@ -463,14 +466,14 @@ export default function RestaurantManagementStudio() {
                           min={1}
                           value={selectedTable.capacity[key]}
                           onChange={(event) => handleCapacityChange(key, Number(event.target.value))}
-                          className="rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100"
+                          className="rounded-lg border border-lundies-stone/60 px-3 py-2 text-sm text-lundies-charcoal shadow-sm focus:border-lundies-heather focus:outline-none focus:ring-1 focus:ring-lundies-heather"
                         />
                       </label>
                     ))}
                   </div>
 
                   <div className="grid gap-3">
-                    <span className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                    <span className="text-xs font-semibold uppercase tracking-wide text-lundies-peat">
                       Zone
                     </span>
                     <div className="grid gap-2 sm:grid-cols-2">
@@ -479,23 +482,29 @@ export default function RestaurantManagementStudio() {
                           type="button"
                           key={option.value}
                           onClick={() => handleZoneChange(option.value)}
-                          className={`flex flex-col items-start gap-1 rounded-xl border px-4 py-3 text-left transition hover:border-emerald-500 hover:bg-emerald-50/40 dark:hover:bg-emerald-900/20 ${
+                          className={`flex flex-col items-start gap-1 rounded-xl border px-4 py-3 text-left transition ${
                             selectedTable.zone === option.value
-                              ? 'border-emerald-500 bg-emerald-50/60 dark:border-emerald-400 dark:bg-emerald-900/40'
-                              : 'border-slate-200 dark:border-slate-700'
+                              ? 'border-lundies-heather bg-lundies-heather/20 shadow-inner'
+                              : 'border-lundies-stone/60 bg-white/95 hover:border-lundies-heather hover:bg-lundies-heather/15'
                           }`}
                         >
-                          <span className="text-sm font-semibold text-slate-900 dark:text-slate-100">
+                          <span
+                            className={`text-sm font-semibold ${
+                              selectedTable.zone === option.value
+                                ? 'text-lundies-heather'
+                                : 'text-lundies-charcoal'
+                            }`}
+                          >
                             {option.label}
                           </span>
-                          <span className="text-xs text-slate-500 dark:text-slate-400">{option.description}</span>
+                          <span className="text-xs text-lundies-peat">{option.description}</span>
                         </button>
                       ))}
                     </div>
                   </div>
 
                   <div className="grid gap-3">
-                    <span className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                    <span className="text-xs font-semibold uppercase tracking-wide text-lundies-peat">
                       Status
                     </span>
                     <div className="flex flex-wrap gap-2">
@@ -506,8 +515,8 @@ export default function RestaurantManagementStudio() {
                           onClick={() => handleStatusChange(status)}
                           className={`rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide transition ${
                             selectedTable.status === status
-                              ? 'bg-emerald-600 text-white shadow'
-                              : 'border border-slate-300 text-slate-500 hover:border-emerald-400 hover:text-emerald-500 dark:border-slate-700 dark:text-slate-400'
+                              ? 'bg-lundies-heather text-white shadow'
+                              : 'border border-lundies-stone/60 text-lundies-peat hover:border-lundies-heather hover:text-lundies-heather'
                           }`}
                         >
                           {status}
@@ -517,7 +526,7 @@ export default function RestaurantManagementStudio() {
                   </div>
 
                   <div className="grid gap-3">
-                    <span className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                    <span className="text-xs font-semibold uppercase tracking-wide text-lundies-peat">
                       Features
                     </span>
                     <div className="grid gap-2 sm:grid-cols-2">
@@ -528,16 +537,20 @@ export default function RestaurantManagementStudio() {
                             type="button"
                             key={option.value}
                             onClick={() => toggleTableFeature(option.value)}
-                            className={`flex flex-col items-start gap-1 rounded-xl border px-4 py-3 text-left transition hover:border-emerald-500 hover:bg-emerald-50/40 dark:hover:bg-emerald-900/20 ${
+                            className={`flex flex-col items-start gap-1 rounded-xl border px-4 py-3 text-left transition hover:border-lundies-heather hover:bg-lundies-heather/15 ${
                               active
-                                ? 'border-emerald-500 bg-emerald-50/60 text-emerald-700 dark:border-emerald-400 dark:bg-emerald-900/40 dark:text-emerald-200'
-                                : 'border-slate-200 text-slate-600 dark:border-slate-700 dark:text-slate-300'
+                                ? 'border-lundies-heather bg-lundies-heather/20 text-lundies-heather'
+                                : 'border-lundies-stone/60 bg-white/95 text-lundies-peat hover:border-lundies-heather hover:bg-lundies-heather/10'
                             }`}
                           >
-                            <span className="text-sm font-semibold text-slate-900 dark:text-slate-100">
+                            <span
+                              className={`text-sm font-semibold ${
+                                active ? 'text-lundies-heather' : 'text-lundies-charcoal'
+                              }`}
+                            >
                               {option.label}
                             </span>
-                            <span className="text-xs text-slate-500 dark:text-slate-400">{option.description}</span>
+                            <span className="text-xs text-lundies-peat">{option.description}</span>
                           </button>
                         )
                       })}
@@ -545,7 +558,7 @@ export default function RestaurantManagementStudio() {
                   </div>
 
                   <div className="grid gap-3">
-                    <span className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                    <span className="text-xs font-semibold uppercase tracking-wide text-lundies-peat">
                       Accessibility
                     </span>
                     <div className="flex flex-wrap gap-2">
@@ -558,8 +571,8 @@ export default function RestaurantManagementStudio() {
                             onClick={() => toggleAccessibility(option.value)}
                             className={`rounded-full px-3 py-1 text-xs font-medium transition ${
                               active
-                                ? 'bg-sky-600 text-white shadow-sm'
-                                : 'border border-slate-300 text-slate-500 hover:border-sky-400 hover:text-sky-600 dark:border-slate-700 dark:text-slate-400'
+                                ? 'bg-lundies-heather text-white shadow-sm'
+                                : 'border border-lundies-stone/60 text-lundies-peat hover:border-lundies-heather hover:text-lundies-heather'
                             }`}
                           >
                             {option.label}
@@ -567,14 +580,14 @@ export default function RestaurantManagementStudio() {
                         )
                       })}
                     </div>
-                    <p className="text-xs text-slate-500 dark:text-slate-400">
+                    <p className="text-xs text-lundies-peat">
                       Accessibility badges display on the guest floor plan and feed the concierge assistant for pre-arrival
                       planning.
                     </p>
                   </div>
 
                   <div className="grid gap-3">
-                    <span className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                    <span className="text-xs font-semibold uppercase tracking-wide text-lundies-peat">
                       Combinable Tables
                     </span>
                     <div className="grid gap-2 sm:grid-cols-2">
@@ -587,15 +600,21 @@ export default function RestaurantManagementStudio() {
                               type="button"
                               key={table.id}
                               onClick={() => toggleCombination(table.id)}
-                              className={`flex items-center justify-between gap-3 rounded-xl border px-4 py-3 text-left transition hover:border-emerald-500 hover:bg-emerald-50/40 dark:hover:bg-emerald-900/20 ${
+                              className={`flex items-center justify-between gap-3 rounded-xl border px-4 py-3 text-left transition ${
                                 combined
-                                  ? 'border-emerald-500 bg-emerald-50/60 text-emerald-700 dark:border-emerald-400 dark:bg-emerald-900/40'
-                                  : 'border-slate-200 text-slate-600 dark:border-slate-700 dark:text-slate-300'
+                                  ? 'border-lundies-heather bg-lundies-heather/20 text-lundies-heather shadow-inner'
+                                  : 'border-lundies-stone/60 bg-white/95 text-lundies-peat hover:border-lundies-heather hover:bg-lundies-heather/10'
                               }`}
                             >
                               <div>
-                                <p className="text-sm font-semibold text-slate-900 dark:text-slate-100">{table.label}</p>
-                                <p className="text-xs text-slate-500 dark:text-slate-400">
+                                <p
+                                  className={`text-sm font-semibold ${
+                                    combined ? 'text-lundies-heather' : 'text-lundies-charcoal'
+                                  }`}
+                                >
+                                  {table.label}
+                                </p>
+                                <p className="text-xs text-lundies-peat">
                                   Default {table.capacity.default} seats · {formatZoneLabel(table.zone)} zone
                                 </p>
                               </div>
@@ -606,48 +625,48 @@ export default function RestaurantManagementStudio() {
                           )
                         })}
                     </div>
-                    <p className="text-xs text-slate-500 dark:text-slate-400">
+                    <p className="text-xs text-lundies-peat">
                       {combinationSummary.tables} tables · {combinationSummary.seats} guests when combined with current configuration.
                     </p>
                   </div>
 
                   <div className="grid gap-3">
-                    <span className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                    <span className="text-xs font-semibold uppercase tracking-wide text-lundies-peat">
                       Notes for Team Briefing
                     </span>
                     <textarea
                       value={selectedTable.notes ?? ''}
                       onChange={(event) => handleNotesChange(event.target.value)}
                       rows={3}
-                      className="rounded-xl border border-slate-300 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100"
+                      className="rounded-xl border border-lundies-stone/60 bg-white/95 px-3 py-2 text-sm text-lundies-charcoal shadow-sm focus:border-lundies-heather focus:outline-none focus:ring-1 focus:ring-lundies-heather"
                       placeholder="Capture service notes, celebration cues, or pairing suggestions for staff."
                     />
                   </div>
                 </div>
               ) : (
-                <p className="mt-4 text-sm text-slate-500 dark:text-slate-400">Select a table to configure settings.</p>
+                <p className="mt-4 text-sm text-lundies-peat">Select a table to configure settings.</p>
               )}
             </div>
 
-            <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
-              <h2 className="text-xl font-semibold text-slate-900 dark:text-white">Service Period Configuration</h2>
-              <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+            <div className="rounded-3xl border border-lundies-stone/60 bg-white/95 p-6 shadow-lg shadow-lundies-stone/30">
+              <h2 className="text-xl font-semibold text-lundies-charcoal">Service Period Configuration</h2>
+              <p className="mt-1 text-sm text-lundies-peat">
                 Control opening times, seating duration, and which zones are offered to guests for each service.
               </p>
               <div className="mt-4 space-y-5">
-                {periods.map((period) => (
-                  <div
-                    key={period.id}
-                    className="rounded-2xl border border-slate-200 p-4 transition hover:border-emerald-400 dark:border-slate-800 dark:hover:border-emerald-500/60"
-                  >
+                  {periods.map((period) => (
+                    <div
+                      key={period.id}
+                      className="rounded-2xl border border-lundies-stone/60 bg-white/95 p-4 transition hover:border-lundies-heather hover:shadow-md"
+                    >
                     <div className="flex flex-wrap items-center justify-between gap-3">
                       <div>
-                        <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">{period.name}</h3>
-                        <p className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                          <h3 className="text-lg font-semibold text-lundies-charcoal">{period.name}</h3>
+                        <p className="text-xs uppercase tracking-wide text-lundies-peat">
                           Last booking {period.lastSeatingTime} · Max party {period.maxPartySize}
                         </p>
                       </div>
-                      <div className="flex gap-2 text-xs text-slate-500 dark:text-slate-400">
+                      <div className="flex gap-2 text-xs text-lundies-peat">
                         <span>{period.startTime}</span>
                         <span aria-hidden="true">—</span>
                         <span>{period.endTime}</span>
@@ -656,29 +675,29 @@ export default function RestaurantManagementStudio() {
 
                     <div className="mt-3 grid gap-3 md:grid-cols-2">
                       <label className="flex flex-col gap-1">
-                        <span className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                        <span className="text-xs font-semibold uppercase tracking-wide text-lundies-peat">
                           Start Time
                         </span>
                         <input
                           type="time"
                           value={period.startTime}
                           onChange={(event) => updateServicePeriod(period.id, { startTime: event.target.value })}
-                          className="rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100"
+                            className="rounded-lg border border-lundies-stone/60 bg-white/95 px-3 py-2 text-sm text-lundies-charcoal focus:border-lundies-heather focus:outline-none focus:ring-1 focus:ring-lundies-heather"
                         />
                       </label>
                       <label className="flex flex-col gap-1">
-                        <span className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                        <span className="text-xs font-semibold uppercase tracking-wide text-lundies-peat">
                           End Time
                         </span>
                         <input
                           type="time"
                           value={period.endTime}
                           onChange={(event) => updateServicePeriod(period.id, { endTime: event.target.value })}
-                          className="rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100"
+                            className="rounded-lg border border-lundies-stone/60 bg-white/95 px-3 py-2 text-sm text-lundies-charcoal focus:border-lundies-heather focus:outline-none focus:ring-1 focus:ring-lundies-heather"
                         />
                       </label>
                       <label className="flex flex-col gap-1">
-                        <span className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                        <span className="text-xs font-semibold uppercase tracking-wide text-lundies-peat">
                           Default Duration (minutes)
                         </span>
                         <input
@@ -688,11 +707,11 @@ export default function RestaurantManagementStudio() {
                           onChange={(event) =>
                             updateServicePeriod(period.id, { defaultDurationMinutes: Number(event.target.value) })
                           }
-                          className="rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100"
+                          className="rounded-lg border border-lundies-stone/60 bg-white/95 px-3 py-2 text-sm text-lundies-charcoal focus:border-lundies-heather focus:outline-none focus:ring-1 focus:ring-lundies-heather"
                         />
                       </label>
                       <label className="flex flex-col gap-1">
-                        <span className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                        <span className="text-xs font-semibold uppercase tracking-wide text-lundies-peat">
                           Turnaround Buffer (minutes)
                         </span>
                         <input
@@ -702,22 +721,22 @@ export default function RestaurantManagementStudio() {
                           onChange={(event) =>
                             updateServicePeriod(period.id, { turnaroundBufferMinutes: Number(event.target.value) })
                           }
-                          className="rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100"
+                          className="rounded-lg border border-lundies-stone/60 bg-white/95 px-3 py-2 text-sm text-lundies-charcoal focus:border-lundies-heather focus:outline-none focus:ring-1 focus:ring-lundies-heather"
                         />
                       </label>
                       <label className="flex flex-col gap-1">
-                        <span className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                        <span className="text-xs font-semibold uppercase tracking-wide text-lundies-peat">
                           Last Seating
                         </span>
                         <input
                           type="time"
                           value={period.lastSeatingTime}
                           onChange={(event) => updateServicePeriod(period.id, { lastSeatingTime: event.target.value })}
-                          className="rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100"
+                          className="rounded-lg border border-lundies-stone/60 bg-white/95 px-3 py-2 text-sm text-lundies-charcoal focus:border-lundies-heather focus:outline-none focus:ring-1 focus:ring-lundies-heather"
                         />
                       </label>
                       <label className="flex flex-col gap-1">
-                        <span className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                        <span className="text-xs font-semibold uppercase tracking-wide text-lundies-peat">
                           Maximum Party Size
                         </span>
                         <input
@@ -725,13 +744,13 @@ export default function RestaurantManagementStudio() {
                           min={2}
                           value={period.maxPartySize}
                           onChange={(event) => updateServicePeriod(period.id, { maxPartySize: Number(event.target.value) })}
-                          className="rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100"
+                          className="rounded-lg border border-lundies-stone/60 bg-white/95 px-3 py-2 text-sm text-lundies-charcoal focus:border-lundies-heather focus:outline-none focus:ring-1 focus:ring-lundies-heather"
                         />
                       </label>
                     </div>
 
                     <div className="mt-3">
-                      <span className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                      <span className="text-xs font-semibold uppercase tracking-wide text-lundies-peat">
                         Zones Available
                       </span>
                       <div className="mt-2 flex flex-wrap gap-2">
@@ -744,8 +763,8 @@ export default function RestaurantManagementStudio() {
                               onClick={() => toggleServiceZone(period.id, zone.value)}
                               className={`rounded-full px-3 py-1 text-xs font-medium transition ${
                                 active
-                                  ? 'bg-emerald-600 text-white shadow-sm'
-                                  : 'border border-slate-300 text-slate-500 hover:border-emerald-400 hover:text-emerald-600 dark:border-slate-700 dark:text-slate-400'
+                                  ? 'bg-lundies-heather text-white shadow-sm'
+                                  : 'border border-lundies-stone/60 text-lundies-peat hover:border-lundies-heather hover:text-lundies-heather'
                               }`}
                             >
                               {zone.label}
@@ -759,7 +778,7 @@ export default function RestaurantManagementStudio() {
                       value={period.notes ?? ''}
                       onChange={(event) => updateServicePeriod(period.id, { notes: event.target.value })}
                       rows={3}
-                      className="mt-3 w-full rounded-xl border border-slate-300 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100"
+                      className="mt-3 w-full rounded-xl border border-lundies-stone/60 bg-white/95 px-3 py-2 text-sm text-lundies-charcoal shadow-sm focus:border-lundies-heather focus:outline-none focus:ring-1 focus:ring-lundies-heather"
                       placeholder="Brief front-of-house on menu focus, live entertainment, or partner promotions."
                     />
                   </div>

--- a/src/app/admin/room-images/page.tsx
+++ b/src/app/admin/room-images/page.tsx
@@ -1,25 +1,24 @@
 'use client';
 
-import RoomImageAdmin from '@/components/admin/RoomImageAdmin';
 import AdminNav from '@/components/admin/AdminNav';
+import RoomImageAdmin from '@/components/admin/RoomImageAdmin';
 
 export default function RoomImagesAdminPage() {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900">
-      <div className="container mx-auto px-4 py-8">
-        <div className="space-y-6">
-          {/* Header */}
-          <div className="text-center">
-            <h1 className="text-4xl font-bold text-white mb-2">Room Image Management</h1>
-            <p className="text-slate-300">Generate and manage AI-powered room images</p>
-          </div>
+    <div className="min-h-screen bg-lundies-linen/80 pb-16 pt-12">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-8 px-6">
+        <header className="flex flex-col items-center gap-2 text-center">
+          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-lundies-moss">Schiehallion Imaging Studio</p>
+          <h1 className="text-4xl font-semibold text-lundies-charcoal">Room Image Management</h1>
+          <p className="max-w-2xl text-sm text-lundies-peat">
+            Generate, curate, and activate AI-powered imagery from within the same warm neutral palette as the public booking
+            experience.
+          </p>
+        </header>
 
-          {/* Navigation */}
-          <AdminNav />
+        <AdminNav className="rounded-3xl border border-lundies-stone/60 bg-white/95 p-6 shadow-lg shadow-lundies-stone/30" />
 
-          {/* Main Content */}
-          <RoomImageAdmin />
-        </div>
+        <RoomImageAdmin />
       </div>
     </div>
   );

--- a/src/components/admin/RoomImageAdmin.tsx
+++ b/src/components/admin/RoomImageAdmin.tsx
@@ -3,7 +3,6 @@
 import React, { useState, useEffect } from 'react';
 import { RoomType } from '@/types/hotel';
 import { roomImageManagementService, type StoredRoomImage } from '@/services/roomImageManagementService';
-import { imageGenerationService, type GeneratedImage } from '@/services/imageGenerationService';
 
 interface RoomImageAdminProps {
   className?: string;
@@ -127,37 +126,36 @@ export default function RoomImageAdmin({ className = '' }: RoomImageAdminProps) 
   return (
     <div className={`space-y-6 ${className}`}>
       {/* Header */}
-      <div className="bg-white dark:bg-gray-800 rounded-lg p-6 shadow-sm border border-gray-200 dark:border-gray-700">
-        <div className="flex items-center justify-between mb-4">
-          <div className="flex items-center">
-            <div className="w-10 h-10 bg-blue-100 dark:bg-blue-900 rounded-lg flex items-center justify-center mr-4">
-              🎨
-            </div>
+      <div className="rounded-3xl border border-lundies-stone/60 bg-white/95 p-6 shadow-lg shadow-lundies-stone/30">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <div className="flex items-start gap-4">
+            <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-lundies-heather/20 text-2xl">🎨</div>
             <div>
-              <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Room Image Admin</h1>
-              <p className="text-sm text-gray-500 dark:text-gray-400">Generate and manage AI-powered room images</p>
+              <p className="text-xs font-semibold uppercase tracking-[0.25em] text-lundies-moss">Creative control</p>
+              <h1 className="text-2xl font-semibold text-lundies-charcoal">Room Image Admin</h1>
+              <p className="text-sm text-lundies-peat">Generate and manage AI-powered room images</p>
             </div>
           </div>
-          
+
           {stats && (
-            <div className="text-right">
-              <div className="text-2xl font-bold text-blue-600">{stats.totalImages}</div>
-              <div className="text-xs text-gray-500">Total Images</div>
-              <div className="text-sm text-green-600">{stats.activeImages} active</div>
+            <div className="text-right text-sm text-lundies-peat">
+              <p className="text-3xl font-semibold text-lundies-charcoal">{stats.totalImages}</p>
+              <p className="text-xs uppercase tracking-[0.2em] text-lundies-moss">Total images</p>
+              <p className="text-xs text-lundies-peat">{stats.activeImages} active placements</p>
             </div>
           )}
         </div>
 
         {/* Room Type Selector */}
-        <div className="flex items-center space-x-4">
-          <label htmlFor="roomTypeSelect" className="text-sm font-medium text-gray-700 dark:text-gray-300">
-            Room Type:
+        <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
+          <label htmlFor="roomTypeSelect" className="text-sm font-medium text-lundies-peat">
+            Room type
           </label>
           <select
             id="roomTypeSelect"
             value={selectedRoomType}
             onChange={(e) => setSelectedRoomType(e.target.value as RoomType)}
-            className="px-3 py-1 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white"
+            className="w-full max-w-xs rounded-lg border border-lundies-stone/60 bg-white/95 px-3 py-2 text-sm text-lundies-charcoal shadow-sm focus:border-lundies-heather focus:outline-none focus:ring-2 focus:ring-lundies-heather"
           >
             {roomTypes.map((type) => (
               <option key={type.value} value={type.value}>
@@ -170,32 +168,30 @@ export default function RoomImageAdmin({ className = '' }: RoomImageAdminProps) 
 
       {/* Messages */}
       {(error || success) && (
-        <div className="flex items-center justify-between">
-          {error && (
-            <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4 flex-1 mr-2">
-              <div className="flex items-center">
-                <svg className="w-5 h-5 text-red-400 mr-3" viewBox="0 0 20 20" fill="currentColor">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+          <div className="flex flex-1 flex-col gap-3 sm:flex-row">
+            {error && (
+              <div className="flex flex-1 items-center gap-3 rounded-2xl border border-lundies-peat/40 bg-lundies-peat/15 px-4 py-3 text-sm text-lundies-peat">
+                <svg className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
                   <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clipRule="evenodd" />
                 </svg>
-                <span className="text-sm text-red-800 dark:text-red-400">{error}</span>
+                <span>{error}</span>
               </div>
-            </div>
-          )}
-          {success && (
-            <div className="bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg p-4 flex-1 mr-2">
-              <div className="flex items-center">
-                <svg className="w-5 h-5 text-green-400 mr-3" viewBox="0 0 20 20" fill="currentColor">
+            )}
+            {success && (
+              <div className="flex flex-1 items-center gap-3 rounded-2xl border border-lundies-heather/40 bg-lundies-heather/15 px-4 py-3 text-sm text-lundies-heather">
+                <svg className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
                   <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
                 </svg>
-                <span className="text-sm text-green-800 dark:text-green-400">{success}</span>
+                <span>{success}</span>
               </div>
-            </div>
-          )}
+            )}
+          </div>
           <button
             onClick={clearMessages}
-            className="p-2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+            className="ml-auto flex h-9 w-9 items-center justify-center rounded-full border border-lundies-stone/60 text-lundies-peat transition hover:border-lundies-heather hover:text-lundies-heather"
           >
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
             </svg>
           </button>
@@ -205,9 +201,9 @@ export default function RoomImageAdmin({ className = '' }: RoomImageAdminProps) 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         {/* Generation Panel */}
         <div className="lg:col-span-1">
-          <div className="bg-white dark:bg-gray-800 rounded-lg p-6 shadow-sm border border-gray-200 dark:border-gray-700 sticky top-6">
-            <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4 flex items-center">
-              <svg className="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <div className="sticky top-6 rounded-3xl border border-lundies-stone/60 bg-white/95 p-6 shadow-lg shadow-lundies-stone/30">
+            <h2 className="mb-4 flex items-center text-lg font-semibold text-lundies-charcoal">
+              <svg className="mr-2 h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
               </svg>
               Generate New Image
@@ -216,7 +212,7 @@ export default function RoomImageAdmin({ className = '' }: RoomImageAdminProps) 
             <div className="space-y-4">
               {/* Style Selection */}
               <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                <label className="mb-2 block text-sm font-medium text-lundies-peat">
                   Style
                 </label>
                 <div className="space-y-2">
@@ -228,9 +224,9 @@ export default function RoomImageAdmin({ className = '' }: RoomImageAdminProps) 
                         value={style}
                         checked={generationForm.style === style}
                         onChange={(e) => setGenerationForm(prev => ({ ...prev, style: e.target.value as any }))}
-                        className="text-blue-600 focus:ring-blue-500"
+                        className="text-lundies-heather focus:ring-lundies-heather"
                       />
-                      <span className="ml-2 text-sm text-gray-700 dark:text-gray-300 capitalize">
+                      <span className="ml-2 text-sm capitalize text-lundies-charcoal">
                         {style}
                       </span>
                     </label>
@@ -240,7 +236,7 @@ export default function RoomImageAdmin({ className = '' }: RoomImageAdminProps) 
 
               {/* Custom Prompt */}
               <div>
-                <label htmlFor="customPrompt" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                <label htmlFor="customPrompt" className="mb-2 block text-sm font-medium text-lundies-peat">
                   Custom Prompt (Optional)
                 </label>
                 <textarea
@@ -248,7 +244,7 @@ export default function RoomImageAdmin({ className = '' }: RoomImageAdminProps) 
                   value={generationForm.customPrompt}
                   onChange={(e) => setGenerationForm(prev => ({ ...prev, customPrompt: e.target.value }))}
                   rows={3}
-                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white text-sm"
+                  className="w-full rounded-lg border border-lundies-stone/60 bg-white/95 px-3 py-2 text-sm text-lundies-charcoal shadow-sm focus:border-lundies-heather focus:outline-none focus:ring-2 focus:ring-lundies-heather"
                   placeholder="Describe specific room features or atmosphere..."
                 />
               </div>
@@ -260,9 +256,9 @@ export default function RoomImageAdmin({ className = '' }: RoomImageAdminProps) 
                   type="checkbox"
                   checked={generationForm.autoSave}
                   onChange={(e) => setGenerationForm(prev => ({ ...prev, autoSave: e.target.checked }))}
-                  className="text-blue-600 focus:ring-blue-500 rounded"
+                  className="rounded text-lundies-heather focus:ring-lundies-heather"
                 />
-                <label htmlFor="autoSave" className="ml-2 text-sm text-gray-700 dark:text-gray-300">
+                <label htmlFor="autoSave" className="ml-2 text-sm text-lundies-peat">
                   Auto-save to gallery
                 </label>
               </div>
@@ -271,19 +267,19 @@ export default function RoomImageAdmin({ className = '' }: RoomImageAdminProps) 
               <button
                 onClick={handleGenerate}
                 disabled={isGenerating}
-                className="w-full px-4 py-3 bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center font-medium"
+                className="flex w-full items-center justify-center rounded-lg bg-lundies-heather px-4 py-3 text-sm font-medium text-white transition hover:bg-lundies-heather/90 disabled:cursor-not-allowed disabled:opacity-50"
               >
                 {isGenerating ? (
                   <>
-                    <svg className="animate-spin -ml-1 mr-3 h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-                      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                    <svg className="-ml-1 mr-3 h-5 w-5 animate-spin text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                      <circle className="opacity-30" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                      <path className="opacity-70" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
                     </svg>
                     Generating...
                   </>
                 ) : (
                   <>
-                    <svg className="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <svg className="mr-2 h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
                     </svg>
                     Generate Image
@@ -296,99 +292,93 @@ export default function RoomImageAdmin({ className = '' }: RoomImageAdminProps) 
 
         {/* Image Gallery */}
         <div className="lg:col-span-2">
-          <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700">
-            <div className="px-6 py-4 border-b border-gray-200 dark:border-gray-700">
-              <div className="flex items-center justify-between">
-                <h2 className="text-lg font-semibold text-gray-900 dark:text-white flex items-center">
-                  <svg className="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
-                  </svg>
-                  {roomTypes.find(rt => rt.value === selectedRoomType)?.label} Images ({images.length})
-                </h2>
-                <button
-                  onClick={loadImages}
-                  disabled={isLoading}
-                  className="px-3 py-1 text-sm bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-md hover:bg-gray-200 dark:hover:bg-gray-600 disabled:opacity-50"
-                >
-                  {isLoading ? 'Loading...' : 'Refresh'}
-                </button>
-              </div>
+          <div className="rounded-3xl border border-lundies-stone/60 bg-white/95 shadow-lg shadow-lundies-stone/30">
+            <div className="flex flex-col gap-3 border-b border-lundies-stone/60 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
+              <h2 className="flex items-center text-lg font-semibold text-lundies-charcoal">
+                <svg className="mr-2 h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                </svg>
+                {roomTypes.find(rt => rt.value === selectedRoomType)?.label} Images ({images.length})
+              </h2>
+              <button
+                onClick={loadImages}
+                disabled={isLoading}
+                className="rounded-full border border-lundies-stone/60 px-4 py-1.5 text-xs font-semibold uppercase tracking-[0.2em] text-lundies-peat transition hover:border-lundies-heather hover:text-lundies-heather disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {isLoading ? 'Loading…' : 'Refresh'}
+              </button>
             </div>
 
             <div className="p-6">
               {isLoading ? (
-                <div className="text-center py-8">
-                  <div className="w-8 h-8 border-2 border-blue-600 border-t-transparent rounded-full animate-spin mx-auto mb-4"></div>
-                  <div className="text-gray-500 dark:text-gray-400">Loading images...</div>
+                <div className="flex flex-col items-center justify-center gap-3 py-10 text-sm text-lundies-peat">
+                  <div className="h-8 w-8 animate-spin rounded-full border-2 border-lundies-heather border-t-transparent" />
+                  <span>Loading images…</span>
                 </div>
               ) : images.length === 0 ? (
-                <div className="text-center py-12">
-                  <div className="text-6xl mb-4">📸</div>
-                  <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-2">No Images Yet</h3>
-                  <p className="text-gray-500 dark:text-gray-400 mb-4">
-                    Generate your first image for {roomTypes.find(rt => rt.value === selectedRoomType)?.label.toLowerCase()} rooms
+                <div className="flex flex-col items-center justify-center gap-3 py-12 text-center">
+                  <div className="text-6xl">📸</div>
+                  <h3 className="text-lg font-semibold text-lundies-charcoal">No images yet</h3>
+                  <p className="max-w-sm text-sm text-lundies-peat">
+                    Generate your first image for {roomTypes.find(rt => rt.value === selectedRoomType)?.label.toLowerCase()} rooms to populate the gallery.
                   </p>
                 </div>
               ) : (
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
                   {images.map((image) => (
-                    <div key={image.id} className="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
-                      <div className="aspect-video bg-gray-100 dark:bg-gray-700">
+                    <div key={image.id} className="overflow-hidden rounded-2xl border border-lundies-stone/60 bg-white/95 shadow-sm">
+                      <div className="aspect-video bg-lundies-linen/70">
                         <img
                           src={image.url}
                           alt={image.prompt}
-                          className="w-full h-full object-cover"
+                          className="h-full w-full object-cover"
                           onError={(e) => {
                             (e.target as HTMLImageElement).style.display = 'none';
                             (e.target as HTMLImageElement).nextElementSibling!.classList.remove('hidden');
                           }}
                         />
-                        <div className="hidden w-full h-full flex items-center justify-center text-gray-400">
+                        <div className="hidden h-full w-full items-center justify-center text-lundies-peat">
                           <div className="text-center">
-                            <svg className="w-12 h-12 mx-auto mb-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <svg className="mx-auto mb-2 h-12 w-12" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
                             </svg>
-                            <div className="text-sm">Image not found</div>
+                            <div className="text-xs">Image not found</div>
                           </div>
                         </div>
                       </div>
-                      
-                      <div className="p-4">
-                        <div className="flex items-center justify-between mb-2">
-                          <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
-                            image.isActive 
-                              ? 'bg-green-100 text-green-800 dark:bg-green-900/20 dark:text-green-400' 
-                              : 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300'
-                          }`}>
+
+                      <div className="space-y-3 p-4">
+                        <div className="flex items-center justify-between">
+                          <span
+                            className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${
+                              image.isActive
+                                ? 'bg-lundies-heather/15 text-lundies-heather'
+                                : 'bg-lundies-linen/80 text-lundies-peat'
+                            }`}
+                          >
                             {image.isActive ? '✓ Active' : 'Inactive'}
                           </span>
-                          <span className="text-xs text-gray-500 dark:text-gray-400 capitalize">
-                            {image.style}
-                          </span>
+                          <span className="text-xs capitalize text-lundies-peat">{image.style}</span>
                         </div>
-                        
-                        <p className="text-sm text-gray-600 dark:text-gray-400 mb-3 line-clamp-2">
-                          {image.prompt}
-                        </p>
-                        
-                        <div className="text-xs text-gray-500 dark:text-gray-500 mb-3">
-                          Generated: {image.generatedAt.toLocaleDateString()}
-                        </div>
-                        
-                        <div className="flex space-x-2">
+
+                        <p className="line-clamp-2 text-sm text-lundies-peat">{image.prompt}</p>
+
+                        <div className="text-xs text-lundies-peat/80">Generated: {image.generatedAt.toLocaleDateString()}</div>
+
+                        <div className="flex gap-2">
                           <button
                             onClick={() => handleToggleActive(image.id, !image.isActive)}
-                            className={`flex-1 px-3 py-2 text-xs font-medium rounded-md ${
+                            className={`flex-1 rounded-lg px-3 py-2 text-xs font-medium transition ${
                               image.isActive
-                                ? 'bg-yellow-100 text-yellow-800 hover:bg-yellow-200 dark:bg-yellow-900/20 dark:text-yellow-400 dark:hover:bg-yellow-900/30'
-                                : 'bg-green-100 text-green-800 hover:bg-green-200 dark:bg-green-900/20 dark:text-green-400 dark:hover:bg-green-900/30'
+                                ? 'bg-lundies-sand/30 text-lundies-peat hover:bg-lundies-sand/40'
+                                : 'bg-lundies-heather/20 text-lundies-heather hover:bg-lundies-heather/30'
                             }`}
                           >
                             {image.isActive ? 'Deactivate' : 'Activate'}
                           </button>
                           <button
                             onClick={() => handleDeleteImage(image.id)}
-                            className="px-3 py-2 text-xs font-medium text-red-800 bg-red-100 rounded-md hover:bg-red-200 dark:bg-red-900/20 dark:text-red-400 dark:hover:bg-red-900/30"
+                            className="rounded-lg px-3 py-2 text-xs font-medium text-lundies-peat transition hover:bg-lundies-peat/15"
                           >
                             Delete
                           </button>
@@ -403,32 +393,33 @@ export default function RoomImageAdmin({ className = '' }: RoomImageAdminProps) 
         </div>
       </div>
 
+
       {/* Statistics Panel */}
       {stats && (
-        <div className="bg-white dark:bg-gray-800 rounded-lg p-6 shadow-sm border border-gray-200 dark:border-gray-700">
-          <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4 flex items-center">
-            <svg className="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <div className="rounded-3xl border border-lundies-stone/60 bg-white/95 p-6 shadow-lg shadow-lundies-stone/30">
+          <h2 className="mb-4 flex items-center text-lg font-semibold text-lundies-charcoal">
+            <svg className="mr-2 h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
             </svg>
-            Gallery Statistics
+            Gallery statistics
           </h2>
-          
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-            <div className="text-center p-4 bg-blue-50 dark:bg-blue-900/20 rounded-lg">
-              <div className="text-2xl font-bold text-blue-600">{stats.totalImages}</div>
-              <div className="text-sm text-blue-600">Total Images</div>
+
+          <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+            <div className="rounded-2xl border border-lundies-stone/60 bg-lundies-linen/80 p-4 text-center">
+              <p className="text-3xl font-semibold text-lundies-charcoal">{stats.totalImages}</p>
+              <p className="text-xs uppercase tracking-[0.2em] text-lundies-moss">Total images</p>
             </div>
-            <div className="text-center p-4 bg-green-50 dark:bg-green-900/20 rounded-lg">
-              <div className="text-2xl font-bold text-green-600">{stats.activeImages}</div>
-              <div className="text-sm text-green-600">Active Images</div>
+            <div className="rounded-2xl border border-lundies-stone/60 bg-lundies-linen/80 p-4 text-center">
+              <p className="text-3xl font-semibold text-lundies-charcoal">{stats.activeImages}</p>
+              <p className="text-xs uppercase tracking-[0.2em] text-lundies-moss">Active placements</p>
             </div>
-            <div className="text-center p-4 bg-purple-50 dark:bg-purple-900/20 rounded-lg">
-              <div className="text-2xl font-bold text-purple-600">{Object.keys(stats.imagesByRoomType).length}</div>
-              <div className="text-sm text-purple-600">Room Types</div>
+            <div className="rounded-2xl border border-lundies-stone/60 bg-lundies-linen/80 p-4 text-center">
+              <p className="text-3xl font-semibold text-lundies-charcoal">{Object.keys(stats.imagesByRoomType).length}</p>
+              <p className="text-xs uppercase tracking-[0.2em] text-lundies-moss">Room archetypes</p>
             </div>
-            <div className="text-center p-4 bg-orange-50 dark:bg-orange-900/20 rounded-lg">
-              <div className="text-2xl font-bold text-orange-600">{Object.keys(stats.imagesByStyle).length}</div>
-              <div className="text-sm text-orange-600">Styles Used</div>
+            <div className="rounded-2xl border border-lundies-stone/60 bg-lundies-linen/80 p-4 text-center">
+              <p className="text-3xl font-semibold text-lundies-charcoal">{Object.keys(stats.imagesByStyle).length}</p>
+              <p className="text-xs uppercase tracking-[0.2em] text-lundies-moss">Visual styles</p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- retheme the restaurant management experience with the new lundies neutrals, updated buttons, legends, and form styling
- refresh the room image admin shell, gallery, and statistics cards to share the neutral palette and typography
- update the room images admin page wrapper to match the shared admin shell and navigation styling

## Testing
- `npm run lint` *(fails: repository has numerous pre-existing lint violations outside the touched files)*
- `npm run type-check` *(fails: repository has unresolved type issues and missing modules outside the touched files)*

------
https://chatgpt.com/codex/tasks/task_e_68d31e558cb883328ff7fb7f41dcb3df