### PR TITLE
refine theme and unify admin and dining styling

### DIFF
--- a/src/app/admin/dashboard/page.tsx
+++ b/src/app/admin/dashboard/page.tsx
@@ -58,36 +58,36 @@ export default function AdminDashboard() {
 
   if (loading || !user || !userProfile) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-gray-100 dark:bg-gray-900">
+      <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-lundies-ivory via-lundies-linen to-lundies-stone dark:from-neutral-950 dark:via-neutral-900 dark:to-neutral-800">
         <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600 mx-auto"></div>
-          <p className="mt-4 text-gray-600 dark:text-gray-400">Loading dashboard...</p>
+          <div className="mx-auto h-12 w-12 animate-spin rounded-full border-b-2 border-lundies-moss"></div>
+          <p className="mt-4 text-sm uppercase tracking-[0.3em] text-lundies-peat/70 dark:text-neutral-300/80">Loading dashboard...</p>
         </div>
       </div>
     )
   }
 
   return (
-    <div className="min-h-screen bg-gray-100 dark:bg-gray-900">
+    <div className="min-h-screen bg-gradient-to-br from-lundies-ivory via-lundies-linen to-lundies-stone text-lundies-charcoal dark:from-neutral-950 dark:via-neutral-900 dark:to-neutral-800">
       {/* Header */}
-      <header className="bg-white dark:bg-gray-800 shadow">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex justify-between items-center py-6">
-            <div className="flex items-center">
-              <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
+      <header className="border-b border-lundies-stone/60 bg-white/80 shadow-sm backdrop-blur-sm dark:border-neutral-700 dark:bg-neutral-900/80">
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+          <div className="flex items-center justify-between py-6">
+            <div className="flex items-center gap-4">
+              <h1 className="text-3xl font-bold text-lundies-charcoal dark:text-neutral-50">
                 Admin Dashboard
               </h1>
-              <span className="ml-4 px-2 py-1 text-xs font-semibold bg-indigo-100 text-indigo-800 rounded-full">
+              <span className="rounded-full bg-lundies-linen/90 px-3 py-1 text-xs font-semibold tracking-[0.3em] text-lundies-peat">
                 {userProfile.role.toUpperCase()}
               </span>
             </div>
             <div className="flex items-center space-x-4">
-              <span className="text-sm text-gray-600 dark:text-gray-400">
+              <span className="text-sm text-lundies-peat/80 dark:text-neutral-300">
                 Welcome, {userProfile.profile.firstName || user.email}
               </span>
               <button
                 onClick={handleLogout}
-                className="px-4 py-2 bg-red-600 text-white rounded-md hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500"
+                className="rounded-full border border-lundies-peat/30 px-4 py-2 text-sm font-semibold text-lundies-peat transition hover:bg-lundies-peat/10 focus:outline-none focus:ring-2 focus:ring-lundies-peat/40"
               >
                 Logout
               </button>
@@ -99,70 +99,70 @@ export default function AdminDashboard() {
       {/* Main Content */}
       <main className="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
         {/* Quick Actions */}
-        <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-8">
+        <div className="mb-8 grid grid-cols-1 gap-4 md:grid-cols-4">
           <button
             onClick={() => router.push('/admin/image-generation')}
-            className="bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700 text-white rounded-lg p-4 text-left transition-all duration-200 transform hover:scale-105 shadow-lg"
+            className="group rounded-3xl border border-lundies-stone/60 bg-white/80 p-4 text-left shadow-sm transition duration-200 hover:-translate-y-1 hover:bg-lundies-ivory/80 dark:border-neutral-700 dark:bg-neutral-900/70 dark:hover:bg-neutral-800"
           >
-            <div className="flex items-center justify-between mb-2">
+            <div className="mb-2 flex items-center justify-between text-lundies-charcoal dark:text-neutral-100">
               <div className="text-2xl">🎨</div>
-              <svg className="w-5 h-5 opacity-80" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg className="h-5 w-5 opacity-80" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7l5 5m0 0l-5 5m5-5H6" />
               </svg>
             </div>
-            <h3 className="font-semibold text-lg mb-1">AI Image Studio</h3>
-            <p className="text-sm opacity-90">Generate room, food & scenery images</p>
+            <h3 className="mb-1 text-lg font-semibold text-lundies-charcoal dark:text-neutral-100">AI Image Studio</h3>
+            <p className="text-sm text-lundies-peat/80 dark:text-neutral-300">Curate brand-safe imagery across rooms and dining.</p>
           </button>
 
           <button
             onClick={() => router.push('/admin/restaurant')}
-            className="bg-gradient-to-r from-orange-600 to-red-600 hover:from-orange-700 hover:to-red-700 text-white rounded-lg p-4 text-left transition-all duration-200 transform hover:scale-105 shadow-lg"
+            className="group rounded-3xl border border-lundies-stone/60 bg-white/80 p-4 text-left shadow-sm transition duration-200 hover:-translate-y-1 hover:bg-lundies-ivory/80 dark:border-neutral-700 dark:bg-neutral-900/70 dark:hover:bg-neutral-800"
           >
-            <div className="flex items-center justify-between mb-2">
+            <div className="mb-2 flex items-center justify-between text-lundies-charcoal dark:text-neutral-100">
               <div className="text-2xl">🍽️</div>
-              <svg className="w-5 h-5 opacity-80" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg className="h-5 w-5 opacity-80" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7l5 5m0 0l-5 5m5-5H6" />
               </svg>
             </div>
-            <h3 className="font-semibold text-lg mb-1">Restaurant</h3>
-            <p className="text-sm opacity-90">Manage tables & reservations</p>
+            <h3 className="mb-1 text-lg font-semibold text-lundies-charcoal dark:text-neutral-100">Restaurant</h3>
+            <p className="text-sm text-lundies-peat/80 dark:text-neutral-300">Manage reservations, availability and table layouts.</p>
           </button>
 
-          <div className="bg-gradient-to-r from-green-600 to-teal-600 text-white rounded-lg p-4 text-left shadow-lg">
-            <div className="flex items-center justify-between mb-2">
+          <div className="rounded-3xl border border-lundies-stone/40 bg-white/60 p-4 text-left shadow-sm backdrop-blur-sm dark:border-neutral-700 dark:bg-neutral-900/70">
+            <div className="mb-2 flex items-center justify-between text-lundies-charcoal dark:text-neutral-100">
               <div className="text-2xl">🏨</div>
-              <div className="text-xs bg-white/20 px-2 py-1 rounded">Coming Soon</div>
+              <div className="rounded-full bg-lundies-linen/90 px-2 py-1 text-xs font-semibold tracking-[0.25em] text-lundies-peat">Coming Soon</div>
             </div>
-            <h3 className="font-semibold text-lg mb-1">Room Management</h3>
-            <p className="text-sm opacity-90">Handle bookings & availability</p>
+            <h3 className="mb-1 text-lg font-semibold text-lundies-charcoal dark:text-neutral-100">Room Management</h3>
+            <p className="text-sm text-lundies-peat/80 dark:text-neutral-300">Handle bookings, assignments and availability.</p>
           </div>
 
-          <div className="bg-gradient-to-r from-indigo-600 to-purple-600 text-white rounded-lg p-4 text-left shadow-lg">
-            <div className="flex items-center justify-between mb-2">
+          <div className="rounded-3xl border border-lundies-stone/40 bg-white/60 p-4 text-left shadow-sm backdrop-blur-sm dark:border-neutral-700 dark:bg-neutral-900/70">
+            <div className="mb-2 flex items-center justify-between text-lundies-charcoal dark:text-neutral-100">
               <div className="text-2xl">📊</div>
-              <div className="text-xs bg-white/20 px-2 py-1 rounded">Coming Soon</div>
+              <div className="rounded-full bg-lundies-linen/90 px-2 py-1 text-xs font-semibold tracking-[0.25em] text-lundies-peat">Coming Soon</div>
             </div>
-            <h3 className="font-semibold text-lg mb-1">Analytics</h3>
-            <p className="text-sm opacity-90">View reports & insights</p>
+            <h3 className="mb-1 text-lg font-semibold text-lundies-charcoal dark:text-neutral-100">Analytics</h3>
+            <p className="text-sm text-lundies-peat/80 dark:text-neutral-300">View upcoming performance dashboards & insights.</p>
           </div>
         </div>
 
         {/* Stats Cards */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
-          <div className="bg-white dark:bg-gray-800 overflow-hidden shadow rounded-lg">
+        <div className="mb-8 grid grid-cols-1 gap-6 md:grid-cols-3">
+          <div className="overflow-hidden rounded-3xl border border-lundies-stone/60 bg-white/80 shadow-sm backdrop-blur-sm dark:border-neutral-700 dark:bg-neutral-900/70">
             <div className="p-5">
               <div className="flex items-center">
                 <div className="flex-shrink-0">
-                  <svg className="h-6 w-6 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <svg className="h-6 w-6 text-lundies-moss" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-2.239" />
                   </svg>
                 </div>
                 <div className="ml-5 w-0 flex-1">
                   <dl>
-                    <dt className="text-sm font-medium text-gray-500 dark:text-gray-400 truncate">
+                    <dt className="truncate text-sm font-medium uppercase tracking-[0.25em] text-lundies-peat/70 dark:text-neutral-300/80">
                       Active Staff
                     </dt>
-                    <dd className="text-lg font-medium text-gray-900 dark:text-white">
+                    <dd className="text-lg font-semibold text-lundies-charcoal dark:text-neutral-100">
                       {staffUsers.length}
                     </dd>
                   </dl>
@@ -171,20 +171,20 @@ export default function AdminDashboard() {
             </div>
           </div>
 
-          <div className="bg-white dark:bg-gray-800 overflow-hidden shadow rounded-lg">
+          <div className="overflow-hidden rounded-3xl border border-lundies-stone/60 bg-white/80 shadow-sm backdrop-blur-sm dark:border-neutral-700 dark:bg-neutral-900/70">
             <div className="p-5">
               <div className="flex items-center">
                 <div className="flex-shrink-0">
-                  <svg className="h-6 w-6 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <svg className="h-6 w-6 text-lundies-moss" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v6a2 2 0 002 2h2m0 0h8a2 2 0 002-2V7a2 2 0 00-2-2h-2m0 0V3a2 2 0 10-4 0v2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
                   </svg>
                 </div>
                 <div className="ml-5 w-0 flex-1">
                   <dl>
-                    <dt className="text-sm font-medium text-gray-500 dark:text-gray-400 truncate">
+                    <dt className="truncate text-sm font-medium uppercase tracking-[0.25em] text-lundies-peat/70 dark:text-neutral-300/80">
                       Recent Actions
                     </dt>
-                    <dd className="text-lg font-medium text-gray-900 dark:text-white">
+                    <dd className="text-lg font-semibold text-lundies-charcoal dark:text-neutral-100">
                       {auditLogs.length}
                     </dd>
                   </dl>
@@ -193,20 +193,20 @@ export default function AdminDashboard() {
             </div>
           </div>
 
-          <div className="bg-white dark:bg-gray-800 overflow-hidden shadow rounded-lg">
+          <div className="overflow-hidden rounded-3xl border border-lundies-stone/60 bg-white/80 shadow-sm backdrop-blur-sm dark:border-neutral-700 dark:bg-neutral-900/70">
             <div className="p-5">
               <div className="flex items-center">
                 <div className="flex-shrink-0">
-                  <svg className="h-6 w-6 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <svg className="h-6 w-6 text-lundies-moss" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
                   </svg>
                 </div>
                 <div className="ml-5 w-0 flex-1">
                   <dl>
-                    <dt className="text-sm font-medium text-gray-500 dark:text-gray-400 truncate">
+                    <dt className="truncate text-sm font-medium uppercase tracking-[0.25em] text-lundies-peat/70 dark:text-neutral-300/80">
                       Session Active
                     </dt>
-                    <dd className="text-lg font-medium text-gray-900 dark:text-white">
+                    <dd className="text-lg font-semibold text-lundies-charcoal dark:text-neutral-100">
                       30 min
                     </dd>
                   </dl>
@@ -218,48 +218,52 @@ export default function AdminDashboard() {
 
         {/* Staff Management */}
         {(userProfile.role === 'manager' || userProfile.role === 'admin') && (
-          <div className="bg-white dark:bg-gray-800 shadow rounded-lg mb-8">
+          <div className="mb-8 rounded-3xl border border-lundies-stone/60 bg-white/80 shadow-sm backdrop-blur-sm dark:border-neutral-700 dark:bg-neutral-900/70">
             <div className="px-4 py-5 sm:p-6">
-              <h3 className="text-lg leading-6 font-medium text-gray-900 dark:text-white mb-4">
+              <h3 className="mb-4 text-lg font-semibold uppercase tracking-[0.3em] text-lundies-peat/80 dark:text-neutral-200">
                 Staff Management
               </h3>
               <div className="overflow-x-auto">
-                <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-                  <thead className="bg-gray-50 dark:bg-gray-700">
+                <table className="min-w-full divide-y divide-lundies-stone/40 dark:divide-neutral-700">
+                  <thead className="bg-lundies-linen/80 text-lundies-peat dark:bg-neutral-900/70 dark:text-neutral-200">
                     <tr>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                      <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.3em]">
                         Name
                       </th>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                      <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.3em]">
                         Email
                       </th>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                      <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.3em]">
                         Role
                       </th>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                      <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.3em]">
                         Last Login
                       </th>
                     </tr>
                   </thead>
-                  <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+                  <tbody className="divide-y divide-lundies-stone/30 bg-white/70 text-lundies-charcoal dark:divide-neutral-700 dark:bg-neutral-900/70 dark:text-neutral-100">
                     {staffUsers.map((staff) => (
                       <tr key={staff.uid}>
-                        <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-white">
+                        <td className="whitespace-nowrap px-6 py-4 text-sm font-medium">
                           {staff.profile.firstName} {staff.profile.lastName}
                         </td>
-                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
+                        <td className="whitespace-nowrap px-6 py-4 text-sm text-lundies-peat/80 dark:text-neutral-300">
                           {staff.email}
                         </td>
-                        <td className="px-6 py-4 whitespace-nowrap">
-                          <span className={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full ${
-                            staff.role === 'admin' ? 'bg-red-100 text-red-800' :
-                            staff.role === 'manager' ? 'bg-yellow-100 text-yellow-800' :
-                            'bg-green-100 text-green-800'
-                          }`}>
+                        <td className="whitespace-nowrap px-6 py-4">
+                          <span
+                            className={`inline-flex rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] ${
+                              staff.role === 'admin'
+                                ? 'bg-lundies-peat/15 text-lundies-peat'
+                                : staff.role === 'manager'
+                                  ? 'bg-lundies-sand/40 text-lundies-peat'
+                                  : 'bg-lundies-heather/20 text-lundies-moss'
+                            }`}
+                          >
                             {staff.role}
                           </span>
                         </td>
-                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
+                        <td className="whitespace-nowrap px-6 py-4 text-sm text-lundies-peat/80 dark:text-neutral-300">
                           {staff.lastLogin?.toLocaleDateString()}
                         </td>
                       </tr>
@@ -273,42 +277,42 @@ export default function AdminDashboard() {
 
         {/* Audit Logs */}
         {userProfile.role === 'admin' && (
-          <div className="bg-white dark:bg-gray-800 shadow rounded-lg">
+          <div className="rounded-3xl border border-lundies-stone/60 bg-white/80 shadow-sm backdrop-blur-sm dark:border-neutral-700 dark:bg-neutral-900/70">
             <div className="px-4 py-5 sm:p-6">
-              <h3 className="text-lg leading-6 font-medium text-gray-900 dark:text-white mb-4">
+              <h3 className="mb-4 text-lg font-semibold uppercase tracking-[0.3em] text-lundies-peat/80 dark:text-neutral-200">
                 Recent Audit Logs
               </h3>
               <div className="overflow-x-auto">
-                <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-                  <thead className="bg-gray-50 dark:bg-gray-700">
+                <table className="min-w-full divide-y divide-lundies-stone/40 dark:divide-neutral-700">
+                  <thead className="bg-lundies-linen/80 text-lundies-peat dark:bg-neutral-900/70 dark:text-neutral-200">
                     <tr>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                      <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.3em]">
                         Timestamp
                       </th>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                      <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.3em]">
                         User
                       </th>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                      <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.3em]">
                         Action
                       </th>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                      <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.3em]">
                         Resource
                       </th>
                     </tr>
                   </thead>
-                  <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+                  <tbody className="divide-y divide-lundies-stone/30 bg-white/70 text-lundies-charcoal dark:divide-neutral-700 dark:bg-neutral-900/70 dark:text-neutral-100">
                     {auditLogs.map((log) => (
                       <tr key={log.id}>
-                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
+                        <td className="whitespace-nowrap px-6 py-4 text-sm text-lundies-peat/80 dark:text-neutral-300">
                           {log.timestamp?.toLocaleString()}
                         </td>
-                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-white">
+                        <td className="whitespace-nowrap px-6 py-4 text-sm font-medium">
                           {log.userId.slice(0, 8)}...
                         </td>
-                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-white">
+                        <td className="whitespace-nowrap px-6 py-4 text-sm font-medium">
                           {log.action}
                         </td>
-                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
+                        <td className="whitespace-nowrap px-6 py-4 text-sm text-lundies-peat/80 dark:text-neutral-300">
                           {log.resource}
                         </td>
                       </tr>

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -22,13 +22,13 @@ export default function AdminDashboard() {
   }, []);
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900">
-      <div className="container mx-auto px-4 py-8">
-        <div className="space-y-6">
+    <div className="min-h-screen bg-gradient-to-br from-lundies-ivory via-lundies-linen to-lundies-stone text-lundies-charcoal">
+      <div className="container mx-auto px-4 py-12">
+        <div className="space-y-8">
           {/* Header */}
-          <div className="text-center">
-            <h1 className="text-4xl font-bold text-white mb-2">Admin Dashboard</h1>
-            <p className="text-slate-300">Manage your AI-powered hotel content</p>
+          <div className="text-center space-y-2">
+            <h1 className="text-4xl font-bold tracking-tight">Admin Dashboard</h1>
+            <p className="text-sm uppercase tracking-[0.35em] text-lundies-peat/70">Manage your AI-powered hotel content</p>
           </div>
 
           {/* Navigation */}
@@ -36,42 +36,48 @@ export default function AdminDashboard() {
 
           {/* Stats Overview */}
           {stats && (
-            <div className="bg-white dark:bg-gray-800 rounded-lg p-6 shadow-sm border border-gray-200 dark:border-gray-700">
-              <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-4 flex items-center">
-                <svg className="w-6 h-6 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <div className="rounded-3xl border border-lundies-stone/60 bg-white/70 p-6 shadow-sm backdrop-blur-sm dark:border-neutral-700 dark:bg-neutral-900/70">
+              <h2 className="mb-4 flex items-center gap-2 text-xl font-semibold text-lundies-charcoal dark:text-neutral-100">
+                <svg className="h-6 w-6 text-lundies-moss" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
                 </svg>
                 AI Image Gallery Overview
               </h2>
-              
-              <div className="grid grid-cols-2 md:grid-cols-4 gap-6 mb-6">
-                <div className="text-center p-4 bg-blue-50 dark:bg-blue-900/20 rounded-lg">
-                  <div className="text-3xl font-bold text-blue-600 mb-1">{stats.totalImages}</div>
-                  <div className="text-sm text-blue-600 font-medium">Total Images</div>
+              <div className="mb-6 grid grid-cols-2 gap-4 md:grid-cols-4">
+                <div className="rounded-2xl border border-lundies-stone/40 bg-lundies-ivory/80 p-4 text-center shadow-sm backdrop-blur-sm dark:border-neutral-700/60 dark:bg-neutral-900/70">
+                  <div className="mb-1 text-3xl font-semibold text-lundies-charcoal dark:text-neutral-50">{stats.totalImages}</div>
+                  <div className="text-xs font-semibold uppercase tracking-[0.3em] text-lundies-peat/70">Total Images</div>
                 </div>
-                <div className="text-center p-4 bg-green-50 dark:bg-green-900/20 rounded-lg">
-                  <div className="text-3xl font-bold text-green-600 mb-1">{stats.activeImages}</div>
-                  <div className="text-sm text-green-600 font-medium">Active Images</div>
+                <div className="rounded-2xl border border-lundies-stone/40 bg-lundies-ivory/80 p-4 text-center shadow-sm backdrop-blur-sm dark:border-neutral-700/60 dark:bg-neutral-900/70">
+                  <div className="mb-1 text-3xl font-semibold text-lundies-charcoal dark:text-neutral-50">{stats.activeImages}</div>
+                  <div className="text-xs font-semibold uppercase tracking-[0.3em] text-lundies-peat/70">Active Images</div>
                 </div>
-                <div className="text-center p-4 bg-purple-50 dark:bg-purple-900/20 rounded-lg">
-                  <div className="text-3xl font-bold text-purple-600 mb-1">{Object.keys(stats.imagesByRoomType).length}</div>
-                  <div className="text-sm text-purple-600 font-medium">Room Types</div>
+                <div className="rounded-2xl border border-lundies-stone/40 bg-lundies-ivory/80 p-4 text-center shadow-sm backdrop-blur-sm dark:border-neutral-700/60 dark:bg-neutral-900/70">
+                  <div className="mb-1 text-3xl font-semibold text-lundies-charcoal dark:text-neutral-50">{Object.keys(stats.imagesByRoomType).length}</div>
+                  <div className="text-xs font-semibold uppercase tracking-[0.3em] text-lundies-peat/70">Room Types</div>
                 </div>
-                <div className="text-center p-4 bg-orange-50 dark:bg-orange-900/20 rounded-lg">
-                  <div className="text-3xl font-bold text-orange-600 mb-1">{Object.keys(stats.imagesByStyle).length}</div>
-                  <div className="text-sm text-orange-600 font-medium">Styles Used</div>
+                <div className="rounded-2xl border border-lundies-stone/40 bg-lundies-ivory/80 p-4 text-center shadow-sm backdrop-blur-sm dark:border-neutral-700/60 dark:bg-neutral-900/70">
+                  <div className="mb-1 text-3xl font-semibold text-lundies-charcoal dark:text-neutral-50">{Object.keys(stats.imagesByStyle).length}</div>
+                  <div className="text-xs font-semibold uppercase tracking-[0.3em] text-lundies-peat/70">Styles Used</div>
                 </div>
               </div>
 
               {/* Room Type Breakdown */}
               {Object.keys(stats.imagesByRoomType).length > 0 && (
                 <div className="mb-6">
-                  <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-3">Images by Room Type</h3>
-                  <div className="grid grid-cols-2 md:grid-cols-5 gap-3">
+                  <h3 className="mb-3 text-sm font-semibold uppercase tracking-[0.3em] text-lundies-peat/70 dark:text-neutral-300/80">
+                    Images by Room Type
+                  </h3>
+                  <div className="grid grid-cols-2 gap-3 md:grid-cols-5">
                     {Object.entries(stats.imagesByRoomType).map(([roomType, count]: [string, any]) => (
-                      <div key={roomType} className="bg-gray-50 dark:bg-gray-700 rounded-lg p-3 text-center">
-                        <div className="text-lg font-semibold text-gray-900 dark:text-white">{count}</div>
-                        <div className="text-xs text-gray-600 dark:text-gray-400 capitalize">{roomType}</div>
+                      <div
+                        key={roomType}
+                        className="rounded-xl border border-lundies-stone/40 bg-white/70 p-3 text-center shadow-sm backdrop-blur-sm dark:border-neutral-700/60 dark:bg-neutral-900/70"
+                      >
+                        <div className="text-lg font-semibold text-lundies-charcoal dark:text-neutral-50">{count}</div>
+                        <div className="text-xs font-medium uppercase tracking-[0.25em] text-lundies-peat/70 dark:text-neutral-300/80">
+                          {roomType}
+                        </div>
                       </div>
                     ))}
                   </div>
@@ -81,12 +87,19 @@ export default function AdminDashboard() {
               {/* Style Breakdown */}
               {Object.keys(stats.imagesByStyle).length > 0 && (
                 <div>
-                  <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-3">Images by Style</h3>
+                  <h3 className="mb-3 text-sm font-semibold uppercase tracking-[0.3em] text-lundies-peat/70 dark:text-neutral-300/80">
+                    Images by Style
+                  </h3>
                   <div className="grid grid-cols-3 gap-3">
                     {Object.entries(stats.imagesByStyle).map(([style, count]: [string, any]) => (
-                      <div key={style} className="bg-gray-50 dark:bg-gray-700 rounded-lg p-3 text-center">
-                        <div className="text-lg font-semibold text-gray-900 dark:text-white">{count}</div>
-                        <div className="text-xs text-gray-600 dark:text-gray-400 capitalize">{style}</div>
+                      <div
+                        key={style}
+                        className="rounded-xl border border-lundies-stone/40 bg-white/70 p-3 text-center shadow-sm backdrop-blur-sm dark:border-neutral-700/60 dark:bg-neutral-900/70"
+                      >
+                        <div className="text-lg font-semibold text-lundies-charcoal dark:text-neutral-50">{count}</div>
+                        <div className="text-xs font-medium uppercase tracking-[0.25em] text-lundies-peat/70 dark:text-neutral-300/80">
+                          {style}
+                        </div>
                       </div>
                     ))}
                   </div>
@@ -96,69 +109,71 @@ export default function AdminDashboard() {
           )}
 
           {/* Quick Actions */}
-          <div className="bg-white dark:bg-gray-800 rounded-lg p-6 shadow-sm border border-gray-200 dark:border-gray-700">
-            <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-4 flex items-center">
-              <svg className="w-6 h-6 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <div className="rounded-3xl border border-lundies-stone/60 bg-white/70 p-6 shadow-sm backdrop-blur-sm dark:border-neutral-700 dark:bg-neutral-900/70">
+            <h2 className="mb-4 flex items-center gap-2 text-xl font-semibold text-lundies-charcoal dark:text-neutral-100">
+              <svg className="h-6 w-6 text-lundies-moss" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
               </svg>
               Quick Actions
             </h2>
-            
+
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <Link
                 href="/admin/room-images"
-                className="p-4 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-700 rounded-lg hover:bg-blue-100 dark:hover:bg-blue-900/30 transition-colors"
+                className="group rounded-2xl border border-lundies-stone/50 bg-lundies-linen/80 p-4 transition-colors hover:bg-lundies-ivory/90 dark:border-neutral-700/60 dark:bg-neutral-900/70 dark:hover:bg-neutral-800"
               >
-                <div className="flex items-center mb-2">
-                  <span className="text-2xl mr-3">🎨</span>
-                  <span className="font-medium text-blue-900 dark:text-blue-300">Generate Room Images</span>
+                <div className="mb-2 flex items-center">
+                  <span className="mr-3 text-2xl">🎨</span>
+                  <span className="font-medium text-lundies-charcoal dark:text-neutral-100">Generate Room Images</span>
                 </div>
-                <p className="text-sm text-blue-700 dark:text-blue-400">Create stunning AI-powered room photos for your website</p>
+                <p className="text-sm text-lundies-peat/80 dark:text-neutral-300">
+                  Create AI-powered room photography that matches the Schiehallion palette
+                </p>
               </Link>
-              
+
               <Link
                 href="/rooms"
-                className="p-4 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-700 rounded-lg hover:bg-green-100 dark:hover:bg-green-900/30 transition-colors"
+                className="group rounded-2xl border border-lundies-stone/50 bg-white/70 p-4 transition-colors hover:bg-lundies-ivory/80 dark:border-neutral-700/60 dark:bg-neutral-900/70 dark:hover:bg-neutral-800"
               >
-                <div className="flex items-center mb-2">
-                  <span className="text-2xl mr-3">🏨</span>
-                  <span className="font-medium text-green-900 dark:text-green-300">View Rooms</span>
+                <div className="mb-2 flex items-center">
+                  <span className="mr-3 text-2xl">🏨</span>
+                  <span className="font-medium text-lundies-charcoal dark:text-neutral-100">View Rooms</span>
                 </div>
-                <p className="text-sm text-green-700 dark:text-green-400">See how your AI-generated images look on the website</p>
+                <p className="text-sm text-lundies-peat/80 dark:text-neutral-300">Review how curated imagery appears on guest pages</p>
               </Link>
             </div>
           </div>
 
           {/* Getting Started */}
           {(!stats || stats.totalImages === 0) && (
-            <div className="bg-white dark:bg-gray-800 rounded-lg p-6 shadow-sm border border-gray-200 dark:border-gray-700">
-              <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-4 flex items-center">
-                <svg className="w-6 h-6 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <div className="rounded-3xl border border-lundies-stone/60 bg-white/70 p-6 shadow-sm backdrop-blur-sm dark:border-neutral-700 dark:bg-neutral-900/70">
+              <h2 className="mb-4 flex items-center gap-2 text-xl font-semibold text-lundies-charcoal dark:text-neutral-100">
+                <svg className="h-6 w-6 text-lundies-moss" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
                 </svg>
                 Getting Started
               </h2>
-              
-              <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-700 rounded-lg p-4">
-                <h3 className="font-medium text-blue-900 dark:text-blue-300 mb-2">Welcome to AI Room Image Management!</h3>
-                <p className="text-sm text-blue-700 dark:text-blue-400 mb-4">
-                  You haven't generated any room images yet. Get started by creating your first AI-powered room image.
+
+              <div className="rounded-2xl border border-lundies-stone/50 bg-lundies-linen/80 p-4 dark:border-neutral-700/60 dark:bg-neutral-900/70">
+                <h3 className="mb-2 font-medium text-lundies-charcoal dark:text-neutral-100">Welcome to AI Room Image Management!</h3>
+                <p className="mb-4 text-sm text-lundies-peat/80 dark:text-neutral-300">
+                  You haven&apos;t generated any room images yet. Curate your first collection to see it appear across guest journeys.
                 </p>
-                <div className="space-y-2 text-sm text-blue-700 dark:text-blue-400">
+                <div className="space-y-2 text-sm text-lundies-peat/80 dark:text-neutral-300">
                   <div className="flex items-center">
-                    <span className="w-6 h-6 bg-blue-100 dark:bg-blue-800 rounded-full flex items-center justify-center text-xs font-bold mr-2">1</span>
+                    <span className="mr-2 flex h-6 w-6 items-center justify-center rounded-full bg-white/80 text-xs font-semibold text-lundies-charcoal shadow-sm dark:bg-neutral-800 dark:text-neutral-100">1</span>
                     Go to Room Images admin panel
                   </div>
                   <div className="flex items-center">
-                    <span className="w-6 h-6 bg-blue-100 dark:bg-blue-800 rounded-full flex items-center justify-center text-xs font-bold mr-2">2</span>
+                    <span className="mr-2 flex h-6 w-6 items-center justify-center rounded-full bg-white/80 text-xs font-semibold text-lundies-charcoal shadow-sm dark:bg-neutral-800 dark:text-neutral-100">2</span>
                     Select a room type and style
                   </div>
                   <div className="flex items-center">
-                    <span className="w-6 h-6 bg-blue-100 dark:bg-blue-800 rounded-full flex items-center justify-center text-xs font-bold mr-2">3</span>
+                    <span className="mr-2 flex h-6 w-6 items-center justify-center rounded-full bg-white/80 text-xs font-semibold text-lundies-charcoal shadow-sm dark:bg-neutral-800 dark:text-neutral-100">3</span>
                     Generate and activate your images
                   </div>
                   <div className="flex items-center">
-                    <span className="w-6 h-6 bg-blue-100 dark:bg-blue-800 rounded-full flex items-center justify-center text-xs font-bold mr-2">4</span>
+                    <span className="mr-2 flex h-6 w-6 items-center justify-center rounded-full bg-white/80 text-xs font-semibold text-lundies-charcoal shadow-sm dark:bg-neutral-800 dark:text-neutral-100">4</span>
                     View them live on your rooms page
                   </div>
                 </div>

--- a/src/app/admin/restaurant/page.tsx
+++ b/src/app/admin/restaurant/page.tsx
@@ -32,43 +32,43 @@ const zoneBackgrounds: ZoneBackground[] = [
   {
     zone: 'window',
     style: { left: '0%', top: '0%', width: '42%', height: '48%' },
-    className: 'bg-sky-200/30 dark:bg-sky-900/30 border-sky-400/60',
+    className: 'bg-lundies-linen/60 border-lundies-stone/60 dark:bg-neutral-900/50 dark:border-neutral-700',
   },
   {
     zone: 'main_dining',
     style: { left: '38%', top: '6%', width: '54%', height: '56%' },
-    className: 'bg-amber-200/30 dark:bg-amber-900/30 border-amber-400/60',
+    className: 'bg-lundies-sand/50 border-lundies-peat/40 dark:bg-neutral-900/60 dark:border-neutral-700',
   },
   {
     zone: 'private',
     style: { left: '4%', top: '52%', width: '34%', height: '40%' },
-    className: 'bg-rose-200/30 dark:bg-rose-900/30 border-rose-400/60',
+    className: 'bg-lundies-stone/60 border-lundies-charcoal/40 dark:bg-neutral-900/60 dark:border-neutral-700',
   },
   {
     zone: 'terrace',
     style: { left: '38%', top: '60%', width: '34%', height: '32%' },
-    className: 'bg-emerald-200/30 dark:bg-emerald-900/30 border-emerald-400/60',
+    className: 'bg-lundies-heather/50 border-lundies-moss/50 dark:bg-neutral-900/60 dark:border-neutral-700',
   },
   {
     zone: 'chef_counter',
     style: { left: '72%', top: '58%', width: '24%', height: '28%' },
-    className: 'bg-indigo-200/30 dark:bg-indigo-900/30 border-indigo-400/60',
+    className: 'bg-lundies-peat/40 border-lundies-charcoal/50 dark:bg-neutral-900/60 dark:border-neutral-700',
   },
 ]
 
 const zoneBadgeStyles: Record<TableZone, string> = {
-  main_dining: 'bg-amber-100 text-amber-700 dark:bg-amber-900/60 dark:text-amber-200',
-  window: 'bg-sky-100 text-sky-700 dark:bg-sky-900/60 dark:text-sky-200',
-  private: 'bg-rose-100 text-rose-700 dark:bg-rose-900/60 dark:text-rose-200',
-  terrace: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/60 dark:text-emerald-200',
-  chef_counter: 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/60 dark:text-indigo-200',
+  main_dining: 'bg-lundies-sand/40 text-lundies-peat dark:bg-neutral-900/60 dark:text-neutral-200',
+  window: 'bg-lundies-linen/70 text-lundies-peat dark:bg-neutral-900/60 dark:text-neutral-200',
+  private: 'bg-lundies-stone/50 text-lundies-charcoal dark:bg-neutral-900/60 dark:text-neutral-200',
+  terrace: 'bg-lundies-heather/40 text-lundies-moss dark:bg-neutral-900/60 dark:text-neutral-200',
+  chef_counter: 'bg-lundies-peat/30 text-lundies-charcoal dark:bg-neutral-900/60 dark:text-neutral-200',
 }
 
 const tableStatusStyles: Record<RestaurantTable['status'], string> = {
-  available: 'border-emerald-500/70 bg-white/80 dark:bg-slate-900/80',
-  held: 'border-amber-500/70 bg-amber-50/80 dark:bg-amber-900/40',
-  reserved: 'border-rose-500/70 bg-rose-50/80 dark:bg-rose-900/40',
-  maintenance: 'border-slate-400/70 bg-slate-100/70 dark:bg-slate-800/60',
+  available: 'border-lundies-moss/70 bg-white/80 dark:bg-neutral-900/70',
+  held: 'border-lundies-sand/70 bg-lundies-sand/30 dark:bg-neutral-900/60',
+  reserved: 'border-lundies-peat/70 bg-lundies-peat/20 dark:bg-neutral-900/60',
+  maintenance: 'border-lundies-stone/70 bg-lundies-stone/40 dark:bg-neutral-900/60',
 }
 
 function normaliseCapacity(capacity: RestaurantTable['capacity']): RestaurantTable['capacity'] {
@@ -301,13 +301,13 @@ export default function RestaurantManagementStudio() {
   }
 
   return (
-    <div className="min-h-screen bg-slate-100 py-10 dark:bg-slate-950">
+    <div className="min-h-screen bg-gradient-to-br from-lundies-ivory via-lundies-linen to-lundies-stone py-10 text-lundies-charcoal dark:from-neutral-950 dark:via-neutral-900 dark:to-neutral-800">
       <div className="mx-auto flex max-w-7xl flex-col gap-10 px-6">
-        <header className="flex flex-col gap-4 rounded-2xl bg-white p-8 shadow-sm ring-1 ring-slate-900/5 dark:bg-slate-900 dark:ring-white/10">
+        <header className="flex flex-col gap-4 rounded-3xl border border-lundies-stone/60 bg-white/80 p-8 shadow-sm backdrop-blur-sm dark:border-neutral-700 dark:bg-neutral-900/80">
           <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
             <div>
-              <p className="text-sm uppercase tracking-wider text-slate-500 dark:text-slate-400">Restaurant Module</p>
-              <h1 className="text-3xl font-semibold text-slate-900 dark:text-white">
+              <p className="text-sm uppercase tracking-[0.35em] text-lundies-peat/70 dark:text-neutral-300/80">Restaurant Module</p>
+              <h1 className="text-3xl font-semibold text-lundies-charcoal dark:text-neutral-50">
                 Table Management Studio
               </h1>
             </div>
@@ -315,20 +315,20 @@ export default function RestaurantManagementStudio() {
               <button
                 type="button"
                 onClick={resetLayout}
-                className="rounded-lg border border-slate-300 px-4 py-2 text-sm font-medium text-slate-600 transition hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+                className="rounded-full border border-lundies-stone/60 px-4 py-2 text-sm font-semibold text-lundies-peat transition hover:bg-lundies-linen/70 dark:border-neutral-700 dark:text-neutral-200 dark:hover:bg-neutral-800"
               >
                 Reset to Defaults
               </button>
               <button
                 type="button"
                 onClick={addServicePeriod}
-                className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-emerald-500"
+                className="rounded-full bg-lundies-moss px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-lundies-heather"
               >
                 Add Service Period
               </button>
             </div>
           </div>
-          <p className="max-w-3xl text-sm text-slate-600 dark:text-slate-300">
+          <p className="max-w-3xl text-sm text-lundies-peat/80 dark:text-neutral-300">
             Drag tables to rearrange the floor plan, configure capacity rules, and map service periods to guest-facing
             experiences. Every change syncs with live availability and the guest table selector.
           </p>
@@ -336,30 +336,30 @@ export default function RestaurantManagementStudio() {
 
         <main className="grid gap-8 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,0.8fr)]">
           <section>
-            <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
-              <div className="mb-4 flex items-center justify-between">
+            <div className="rounded-3xl border border-lundies-stone/60 bg-white/80 p-6 shadow-sm backdrop-blur-sm dark:border-neutral-700 dark:bg-neutral-900/80">
+              <div className="mb-4 flex items-center justify-between text-lundies-charcoal dark:text-neutral-100">
                 <div>
-                  <h2 className="text-xl font-semibold text-slate-900 dark:text-white">Floor Plan Editor</h2>
-                  <p className="text-sm text-slate-500 dark:text-slate-400">
+                  <h2 className="text-xl font-semibold">Floor Plan Editor</h2>
+                  <p className="text-sm text-lundies-peat/80 dark:text-neutral-300">
                     Visualise the dining room, highlight zones, and drag tables into new positions.
                   </p>
                 </div>
-                <div className="flex gap-3 text-xs text-slate-500 dark:text-slate-400">
+                <div className="flex gap-3 text-xs text-lundies-peat/70 dark:text-neutral-300">
                   <span className="flex items-center gap-1">
-                    <span className="h-3 w-3 rounded-full bg-emerald-500" /> Available
+                    <span className="h-3 w-3 rounded-full bg-lundies-moss" /> Available
                   </span>
                   <span className="flex items-center gap-1">
-                    <span className="h-3 w-3 rounded-full bg-amber-500" /> Held
+                    <span className="h-3 w-3 rounded-full bg-lundies-sand" /> Held
                   </span>
                   <span className="flex items-center gap-1">
-                    <span className="h-3 w-3 rounded-full bg-rose-500" /> Reserved
+                    <span className="h-3 w-3 rounded-full bg-lundies-peat" /> Reserved
                   </span>
                 </div>
               </div>
 
               <div
                 ref={floorplanRef}
-                className="relative mx-auto flex max-w-full items-center justify-center overflow-hidden rounded-2xl border border-slate-200 bg-slate-50 shadow-inner dark:border-slate-800 dark:bg-slate-950"
+                className="relative mx-auto flex max-w-full items-center justify-center overflow-hidden rounded-3xl border border-lundies-stone/60 bg-lundies-linen/60 shadow-inner dark:border-neutral-700 dark:bg-neutral-950"
                 style={{
                   width: FLOORPLAN_WIDTH,
                   height: FLOORPLAN_HEIGHT,
@@ -375,7 +375,7 @@ export default function RestaurantManagementStudio() {
                       className={`absolute rounded-xl border ${item.className}`}
                       style={item.style}
                     >
-                      <span className="absolute left-2 top-2 rounded-full bg-white/90 px-2 py-1 text-xs font-medium text-slate-600 shadow-sm dark:bg-slate-900/80 dark:text-slate-200">
+                      <span className="absolute left-2 top-2 rounded-full bg-white/90 px-2 py-1 text-xs font-medium text-lundies-peat/80 shadow-sm dark:bg-neutral-900/80 dark:text-neutral-200">
                         {formatZoneLabel(item.zone)}
                       </span>
                     </div>
@@ -413,12 +413,12 @@ export default function RestaurantManagementStudio() {
                         height: TABLE_SIZE,
                         transform: `translate(${table.position.x}px, ${table.position.y}px)`,
                       }}
-                      className={`absolute flex flex-col items-center justify-center rounded-xl border-2 px-2 text-center text-sm font-semibold text-slate-700 shadow-md transition focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 dark:text-slate-100 ${tableStatusStyles[table.status]} ${
-                        isSelected ? 'ring-2 ring-emerald-500' : 'ring-0'
+                      className={`absolute flex flex-col items-center justify-center rounded-xl border-2 px-2 text-center text-sm font-semibold text-lundies-charcoal shadow-md transition focus:outline-none focus-visible:ring-2 focus-visible:ring-lundies-moss dark:text-neutral-100 ${tableStatusStyles[table.status]} ${
+                        isSelected ? 'ring-2 ring-lundies-moss' : 'ring-0'
                       } ${draggingId === table.id ? 'cursor-grabbing' : 'cursor-grab'}`}
                     >
                       <span className="text-base font-bold">{table.label}</span>
-                      <span className="text-xs font-medium text-slate-500 dark:text-slate-400">
+                      <span className="text-xs font-medium text-lundies-peat/70 dark:text-lundies-peat/60">
                         {table.capacity.default} seats
                       </span>
                       <span
@@ -434,17 +434,17 @@ export default function RestaurantManagementStudio() {
           </section>
 
           <aside className="space-y-6">
-            <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
-              <h2 className="text-xl font-semibold text-slate-900 dark:text-white">Table Configuration</h2>
+            <div className="rounded-2xl border border-lundies-stone/60 bg-white p-6 shadow-sm dark:border-neutral-800 dark:bg-neutral-900/80">
+              <h2 className="text-xl font-semibold text-lundies-charcoal dark:text-white">Table Configuration</h2>
               {selectedTable ? (
-                <div className="mt-4 space-y-6 text-sm text-slate-600 dark:text-slate-300">
+                <div className="mt-4 space-y-6 text-sm text-lundies-peat/80 dark:text-lundies-peat/50">
                   <div className="grid gap-3">
-                    <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                    <label className="text-xs font-semibold uppercase tracking-wide text-lundies-peat/70 dark:text-lundies-peat/60">
                       Table Label
                     </label>
                     <div className="flex items-center gap-2">
-                      <span className="text-lg font-semibold text-slate-900 dark:text-white">{selectedTable.label}</span>
-                      <span className="rounded-full border border-slate-300 px-2 py-0.5 text-xs text-slate-500 dark:border-slate-700 dark:text-slate-400">
+                      <span className="text-lg font-semibold text-lundies-charcoal dark:text-white">{selectedTable.label}</span>
+                      <span className="rounded-full border border-lundies-stone/60 px-2 py-0.5 text-xs text-lundies-peat/70 dark:border-neutral-700 dark:text-lundies-peat/60">
                         ID: {selectedTable.id}
                       </span>
                     </div>
@@ -453,7 +453,7 @@ export default function RestaurantManagementStudio() {
                   <div className="grid gap-4 md:grid-cols-3">
                     {(['min', 'default', 'max'] as const).map((key) => (
                       <label key={key} className="flex flex-col gap-1">
-                        <span className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                        <span className="text-xs font-semibold uppercase tracking-wide text-lundies-peat/70 dark:text-lundies-peat/60">
                           {key === 'min' && 'Minimum'}
                           {key === 'default' && 'Default'}
                           {key === 'max' && 'Maximum'}
@@ -463,14 +463,14 @@ export default function RestaurantManagementStudio() {
                           min={1}
                           value={selectedTable.capacity[key]}
                           onChange={(event) => handleCapacityChange(key, Number(event.target.value))}
-                          className="rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100"
+                          className="rounded-lg border border-lundies-stone/60 px-3 py-2 text-sm text-lundies-charcoal shadow-sm focus:border-lundies-moss focus:outline-none focus:ring-1 focus:ring-lundies-moss dark:border-neutral-700 dark:bg-neutral-900/80 dark:text-neutral-100"
                         />
                       </label>
                     ))}
                   </div>
 
                   <div className="grid gap-3">
-                    <span className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                    <span className="text-xs font-semibold uppercase tracking-wide text-lundies-peat/70 dark:text-lundies-peat/60">
                       Zone
                     </span>
                     <div className="grid gap-2 sm:grid-cols-2">
@@ -479,23 +479,23 @@ export default function RestaurantManagementStudio() {
                           type="button"
                           key={option.value}
                           onClick={() => handleZoneChange(option.value)}
-                          className={`flex flex-col items-start gap-1 rounded-xl border px-4 py-3 text-left transition hover:border-emerald-500 hover:bg-emerald-50/40 dark:hover:bg-emerald-900/20 ${
+                          className={`flex flex-col items-start gap-1 rounded-xl border px-4 py-3 text-left transition hover:border-lundies-moss hover:bg-lundies-heather/20 dark:hover:bg-neutral-900/40 ${
                             selectedTable.zone === option.value
-                              ? 'border-emerald-500 bg-emerald-50/60 dark:border-emerald-400 dark:bg-emerald-900/40'
-                              : 'border-slate-200 dark:border-slate-700'
+                              ? 'border-lundies-moss bg-lundies-heather/30 dark:border-lundies-moss/70 dark:bg-neutral-900/50'
+                              : 'border-lundies-stone/60 dark:border-neutral-700'
                           }`}
                         >
-                          <span className="text-sm font-semibold text-slate-900 dark:text-slate-100">
+                          <span className="text-sm font-semibold text-lundies-charcoal dark:text-neutral-100">
                             {option.label}
                           </span>
-                          <span className="text-xs text-slate-500 dark:text-slate-400">{option.description}</span>
+                          <span className="text-xs text-lundies-peat/70 dark:text-lundies-peat/60">{option.description}</span>
                         </button>
                       ))}
                     </div>
                   </div>
 
                   <div className="grid gap-3">
-                    <span className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                    <span className="text-xs font-semibold uppercase tracking-wide text-lundies-peat/70 dark:text-lundies-peat/60">
                       Status
                     </span>
                     <div className="flex flex-wrap gap-2">
@@ -506,8 +506,8 @@ export default function RestaurantManagementStudio() {
                           onClick={() => handleStatusChange(status)}
                           className={`rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide transition ${
                             selectedTable.status === status
-                              ? 'bg-emerald-600 text-white shadow'
-                              : 'border border-slate-300 text-slate-500 hover:border-emerald-400 hover:text-emerald-500 dark:border-slate-700 dark:text-slate-400'
+                              ? 'bg-lundies-moss text-white shadow'
+                              : 'border border-lundies-stone/60 text-lundies-peat/70 hover:border-lundies-moss/70 hover:text-lundies-moss dark:border-neutral-700 dark:text-lundies-peat/60'
                           }`}
                         >
                           {status}
@@ -517,7 +517,7 @@ export default function RestaurantManagementStudio() {
                   </div>
 
                   <div className="grid gap-3">
-                    <span className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                    <span className="text-xs font-semibold uppercase tracking-wide text-lundies-peat/70 dark:text-lundies-peat/60">
                       Features
                     </span>
                     <div className="grid gap-2 sm:grid-cols-2">
@@ -528,16 +528,16 @@ export default function RestaurantManagementStudio() {
                             type="button"
                             key={option.value}
                             onClick={() => toggleTableFeature(option.value)}
-                            className={`flex flex-col items-start gap-1 rounded-xl border px-4 py-3 text-left transition hover:border-emerald-500 hover:bg-emerald-50/40 dark:hover:bg-emerald-900/20 ${
+                            className={`flex flex-col items-start gap-1 rounded-xl border px-4 py-3 text-left transition hover:border-lundies-moss hover:bg-lundies-heather/20 dark:hover:bg-neutral-900/40 ${
                               active
-                                ? 'border-emerald-500 bg-emerald-50/60 text-emerald-700 dark:border-emerald-400 dark:bg-emerald-900/40 dark:text-emerald-200'
-                                : 'border-slate-200 text-slate-600 dark:border-slate-700 dark:text-slate-300'
+                                ? 'border-lundies-moss bg-lundies-heather/30 text-lundies-moss dark:border-lundies-moss/70 dark:bg-neutral-900/50 dark:text-neutral-200'
+                                : 'border-lundies-stone/60 text-lundies-peat/80 dark:border-neutral-700 dark:text-lundies-peat/50'
                             }`}
                           >
-                            <span className="text-sm font-semibold text-slate-900 dark:text-slate-100">
+                            <span className="text-sm font-semibold text-lundies-charcoal dark:text-neutral-100">
                               {option.label}
                             </span>
-                            <span className="text-xs text-slate-500 dark:text-slate-400">{option.description}</span>
+                            <span className="text-xs text-lundies-peat/70 dark:text-lundies-peat/60">{option.description}</span>
                           </button>
                         )
                       })}
@@ -545,7 +545,7 @@ export default function RestaurantManagementStudio() {
                   </div>
 
                   <div className="grid gap-3">
-                    <span className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                    <span className="text-xs font-semibold uppercase tracking-wide text-lundies-peat/70 dark:text-lundies-peat/60">
                       Accessibility
                     </span>
                     <div className="flex flex-wrap gap-2">
@@ -558,8 +558,8 @@ export default function RestaurantManagementStudio() {
                             onClick={() => toggleAccessibility(option.value)}
                             className={`rounded-full px-3 py-1 text-xs font-medium transition ${
                               active
-                                ? 'bg-sky-600 text-white shadow-sm'
-                                : 'border border-slate-300 text-slate-500 hover:border-sky-400 hover:text-sky-600 dark:border-slate-700 dark:text-slate-400'
+                                ? 'bg-lundies-moss text-white shadow-sm'
+                                : 'border border-lundies-stone/60 text-lundies-peat/70 hover:border-lundies-moss hover:text-lundies-moss dark:border-neutral-700 dark:text-lundies-peat/60'
                             }`}
                           >
                             {option.label}
@@ -567,14 +567,14 @@ export default function RestaurantManagementStudio() {
                         )
                       })}
                     </div>
-                    <p className="text-xs text-slate-500 dark:text-slate-400">
+                    <p className="text-xs text-lundies-peat/70 dark:text-lundies-peat/60">
                       Accessibility badges display on the guest floor plan and feed the concierge assistant for pre-arrival
                       planning.
                     </p>
                   </div>
 
                   <div className="grid gap-3">
-                    <span className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                    <span className="text-xs font-semibold uppercase tracking-wide text-lundies-peat/70 dark:text-lundies-peat/60">
                       Combinable Tables
                     </span>
                     <div className="grid gap-2 sm:grid-cols-2">
@@ -587,15 +587,15 @@ export default function RestaurantManagementStudio() {
                               type="button"
                               key={table.id}
                               onClick={() => toggleCombination(table.id)}
-                              className={`flex items-center justify-between gap-3 rounded-xl border px-4 py-3 text-left transition hover:border-emerald-500 hover:bg-emerald-50/40 dark:hover:bg-emerald-900/20 ${
+                              className={`flex items-center justify-between gap-3 rounded-xl border px-4 py-3 text-left transition hover:border-lundies-moss hover:bg-lundies-heather/20 dark:hover:bg-neutral-900/40 ${
                                 combined
-                                  ? 'border-emerald-500 bg-emerald-50/60 text-emerald-700 dark:border-emerald-400 dark:bg-emerald-900/40'
-                                  : 'border-slate-200 text-slate-600 dark:border-slate-700 dark:text-slate-300'
+                                  ? 'border-lundies-moss bg-lundies-heather/30 text-lundies-moss dark:border-lundies-moss/70 dark:bg-neutral-900/50'
+                                  : 'border-lundies-stone/60 text-lundies-peat/80 dark:border-neutral-700 dark:text-lundies-peat/50'
                               }`}
                             >
                               <div>
-                                <p className="text-sm font-semibold text-slate-900 dark:text-slate-100">{table.label}</p>
-                                <p className="text-xs text-slate-500 dark:text-slate-400">
+                                <p className="text-sm font-semibold text-lundies-charcoal dark:text-neutral-100">{table.label}</p>
+                                <p className="text-xs text-lundies-peat/70 dark:text-lundies-peat/60">
                                   Default {table.capacity.default} seats · {formatZoneLabel(table.zone)} zone
                                 </p>
                               </div>
@@ -606,48 +606,48 @@ export default function RestaurantManagementStudio() {
                           )
                         })}
                     </div>
-                    <p className="text-xs text-slate-500 dark:text-slate-400">
+                    <p className="text-xs text-lundies-peat/70 dark:text-lundies-peat/60">
                       {combinationSummary.tables} tables · {combinationSummary.seats} guests when combined with current configuration.
                     </p>
                   </div>
 
                   <div className="grid gap-3">
-                    <span className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                    <span className="text-xs font-semibold uppercase tracking-wide text-lundies-peat/70 dark:text-lundies-peat/60">
                       Notes for Team Briefing
                     </span>
                     <textarea
                       value={selectedTable.notes ?? ''}
                       onChange={(event) => handleNotesChange(event.target.value)}
                       rows={3}
-                      className="rounded-xl border border-slate-300 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100"
+                      className="rounded-xl border border-lundies-stone/60 px-3 py-2 text-sm text-lundies-charcoal shadow-sm focus:border-lundies-moss focus:outline-none focus:ring-1 focus:ring-lundies-moss dark:border-neutral-700 dark:bg-neutral-900/80 dark:text-neutral-100"
                       placeholder="Capture service notes, celebration cues, or pairing suggestions for staff."
                     />
                   </div>
                 </div>
               ) : (
-                <p className="mt-4 text-sm text-slate-500 dark:text-slate-400">Select a table to configure settings.</p>
+                <p className="mt-4 text-sm text-lundies-peat/70 dark:text-lundies-peat/60">Select a table to configure settings.</p>
               )}
             </div>
 
-            <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
-              <h2 className="text-xl font-semibold text-slate-900 dark:text-white">Service Period Configuration</h2>
-              <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+            <div className="rounded-2xl border border-lundies-stone/60 bg-white p-6 shadow-sm dark:border-neutral-800 dark:bg-neutral-900/80">
+              <h2 className="text-xl font-semibold text-lundies-charcoal dark:text-white">Service Period Configuration</h2>
+              <p className="mt-1 text-sm text-lundies-peat/70 dark:text-lundies-peat/60">
                 Control opening times, seating duration, and which zones are offered to guests for each service.
               </p>
               <div className="mt-4 space-y-5">
                 {periods.map((period) => (
                   <div
                     key={period.id}
-                    className="rounded-2xl border border-slate-200 p-4 transition hover:border-emerald-400 dark:border-slate-800 dark:hover:border-emerald-500/60"
+                    className="rounded-2xl border border-lundies-stone/60 p-4 transition hover:border-lundies-moss/70 dark:border-neutral-800 dark:hover:border-lundies-moss/60"
                   >
                     <div className="flex flex-wrap items-center justify-between gap-3">
                       <div>
-                        <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">{period.name}</h3>
-                        <p className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                        <h3 className="text-lg font-semibold text-lundies-charcoal dark:text-neutral-100">{period.name}</h3>
+                        <p className="text-xs uppercase tracking-wide text-lundies-peat/70 dark:text-lundies-peat/60">
                           Last booking {period.lastSeatingTime} · Max party {period.maxPartySize}
                         </p>
                       </div>
-                      <div className="flex gap-2 text-xs text-slate-500 dark:text-slate-400">
+                      <div className="flex gap-2 text-xs text-lundies-peat/70 dark:text-lundies-peat/60">
                         <span>{period.startTime}</span>
                         <span aria-hidden="true">—</span>
                         <span>{period.endTime}</span>
@@ -656,29 +656,29 @@ export default function RestaurantManagementStudio() {
 
                     <div className="mt-3 grid gap-3 md:grid-cols-2">
                       <label className="flex flex-col gap-1">
-                        <span className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                        <span className="text-xs font-semibold uppercase tracking-wide text-lundies-peat/70 dark:text-lundies-peat/60">
                           Start Time
                         </span>
                         <input
                           type="time"
                           value={period.startTime}
                           onChange={(event) => updateServicePeriod(period.id, { startTime: event.target.value })}
-                          className="rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100"
+                          className="rounded-lg border border-lundies-stone/60 px-3 py-2 text-sm text-lundies-charcoal focus:border-lundies-moss focus:outline-none focus:ring-1 focus:ring-lundies-moss dark:border-neutral-700 dark:bg-neutral-900/80 dark:text-neutral-100"
                         />
                       </label>
                       <label className="flex flex-col gap-1">
-                        <span className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                        <span className="text-xs font-semibold uppercase tracking-wide text-lundies-peat/70 dark:text-lundies-peat/60">
                           End Time
                         </span>
                         <input
                           type="time"
                           value={period.endTime}
                           onChange={(event) => updateServicePeriod(period.id, { endTime: event.target.value })}
-                          className="rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100"
+                          className="rounded-lg border border-lundies-stone/60 px-3 py-2 text-sm text-lundies-charcoal focus:border-lundies-moss focus:outline-none focus:ring-1 focus:ring-lundies-moss dark:border-neutral-700 dark:bg-neutral-900/80 dark:text-neutral-100"
                         />
                       </label>
                       <label className="flex flex-col gap-1">
-                        <span className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                        <span className="text-xs font-semibold uppercase tracking-wide text-lundies-peat/70 dark:text-lundies-peat/60">
                           Default Duration (minutes)
                         </span>
                         <input
@@ -688,11 +688,11 @@ export default function RestaurantManagementStudio() {
                           onChange={(event) =>
                             updateServicePeriod(period.id, { defaultDurationMinutes: Number(event.target.value) })
                           }
-                          className="rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100"
+                          className="rounded-lg border border-lundies-stone/60 px-3 py-2 text-sm text-lundies-charcoal focus:border-lundies-moss focus:outline-none focus:ring-1 focus:ring-lundies-moss dark:border-neutral-700 dark:bg-neutral-900/80 dark:text-neutral-100"
                         />
                       </label>
                       <label className="flex flex-col gap-1">
-                        <span className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                        <span className="text-xs font-semibold uppercase tracking-wide text-lundies-peat/70 dark:text-lundies-peat/60">
                           Turnaround Buffer (minutes)
                         </span>
                         <input
@@ -702,22 +702,22 @@ export default function RestaurantManagementStudio() {
                           onChange={(event) =>
                             updateServicePeriod(period.id, { turnaroundBufferMinutes: Number(event.target.value) })
                           }
-                          className="rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100"
+                          className="rounded-lg border border-lundies-stone/60 px-3 py-2 text-sm text-lundies-charcoal focus:border-lundies-moss focus:outline-none focus:ring-1 focus:ring-lundies-moss dark:border-neutral-700 dark:bg-neutral-900/80 dark:text-neutral-100"
                         />
                       </label>
                       <label className="flex flex-col gap-1">
-                        <span className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                        <span className="text-xs font-semibold uppercase tracking-wide text-lundies-peat/70 dark:text-lundies-peat/60">
                           Last Seating
                         </span>
                         <input
                           type="time"
                           value={period.lastSeatingTime}
                           onChange={(event) => updateServicePeriod(period.id, { lastSeatingTime: event.target.value })}
-                          className="rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100"
+                          className="rounded-lg border border-lundies-stone/60 px-3 py-2 text-sm text-lundies-charcoal focus:border-lundies-moss focus:outline-none focus:ring-1 focus:ring-lundies-moss dark:border-neutral-700 dark:bg-neutral-900/80 dark:text-neutral-100"
                         />
                       </label>
                       <label className="flex flex-col gap-1">
-                        <span className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                        <span className="text-xs font-semibold uppercase tracking-wide text-lundies-peat/70 dark:text-lundies-peat/60">
                           Maximum Party Size
                         </span>
                         <input
@@ -725,13 +725,13 @@ export default function RestaurantManagementStudio() {
                           min={2}
                           value={period.maxPartySize}
                           onChange={(event) => updateServicePeriod(period.id, { maxPartySize: Number(event.target.value) })}
-                          className="rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100"
+                          className="rounded-lg border border-lundies-stone/60 px-3 py-2 text-sm text-lundies-charcoal focus:border-lundies-moss focus:outline-none focus:ring-1 focus:ring-lundies-moss dark:border-neutral-700 dark:bg-neutral-900/80 dark:text-neutral-100"
                         />
                       </label>
                     </div>
 
                     <div className="mt-3">
-                      <span className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                      <span className="text-xs font-semibold uppercase tracking-wide text-lundies-peat/70 dark:text-lundies-peat/60">
                         Zones Available
                       </span>
                       <div className="mt-2 flex flex-wrap gap-2">
@@ -744,8 +744,8 @@ export default function RestaurantManagementStudio() {
                               onClick={() => toggleServiceZone(period.id, zone.value)}
                               className={`rounded-full px-3 py-1 text-xs font-medium transition ${
                                 active
-                                  ? 'bg-emerald-600 text-white shadow-sm'
-                                  : 'border border-slate-300 text-slate-500 hover:border-emerald-400 hover:text-emerald-600 dark:border-slate-700 dark:text-slate-400'
+                                  ? 'bg-lundies-moss text-white shadow-sm'
+                                  : 'border border-lundies-stone/60 text-lundies-peat/70 hover:border-lundies-moss/70 hover:text-lundies-moss dark:border-neutral-700 dark:text-lundies-peat/60'
                               }`}
                             >
                               {zone.label}
@@ -759,7 +759,7 @@ export default function RestaurantManagementStudio() {
                       value={period.notes ?? ''}
                       onChange={(event) => updateServicePeriod(period.id, { notes: event.target.value })}
                       rows={3}
-                      className="mt-3 w-full rounded-xl border border-slate-300 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100"
+                      className="mt-3 w-full rounded-xl border border-lundies-stone/60 px-3 py-2 text-sm text-lundies-charcoal shadow-sm focus:border-lundies-moss focus:outline-none focus:ring-1 focus:ring-lundies-moss dark:border-neutral-700 dark:bg-neutral-900/80 dark:text-neutral-100"
                       placeholder="Brief front-of-house on menu focus, live entertainment, or partner promotions."
                     />
                   </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,13 +4,15 @@
 
 :root {
   color-scheme: light;
-  --surface-base: 245 241 235;
-  --surface-muted: 233 226 215;
-  --surface-accent: 215 205 193;
-  --accent-green: 143 160 137;
-  --accent-brown: 139 109 90;
+  --surface-base: 248 245 239;
+  --surface-muted: 236 230 220;
+  --surface-accent: 222 212 199;
+  --surface-elevated: 255 255 252;
+  --accent-green: 128 146 124;
+  --accent-brown: 150 125 104;
+  --accent-stone: 190 180 168;
   --text-primary: 26 23 20;
-  --text-muted: 96 92 84;
+  --text-muted: 104 100 94;
 }
 
 body {
@@ -18,12 +20,13 @@ body {
   color: rgb(var(--text-primary));
   background-color: rgb(var(--surface-base));
   background:
-    radial-gradient(circle at 18% 18%, rgba(var(--accent-green) / 0.18), transparent 55%),
-    radial-gradient(circle at 82% 8%, rgba(var(--accent-brown) / 0.12), transparent 45%),
+    radial-gradient(circle at 18% 18%, rgba(var(--accent-green) / 0.12), transparent 55%),
+    radial-gradient(circle at 82% 12%, rgba(var(--accent-brown) / 0.08), transparent 45%),
     linear-gradient(
       to bottom,
-      rgb(var(--surface-base)),
-      rgb(var(--surface-muted)) 45%,
+      rgb(var(--surface-elevated)),
+      rgb(var(--surface-base)) 32%,
+      rgb(var(--surface-muted)) 64%,
       rgb(var(--surface-accent))
     );
   font-feature-settings: 'cv02', 'cv03', 'cv04', 'cv11';

--- a/src/app/restaurant/page.tsx
+++ b/src/app/restaurant/page.tsx
@@ -32,11 +32,11 @@ const FLOORPLAN_HEIGHT = 480
 const TABLE_SIZE = 72
 
 const zoneBadgeStyles: Record<TableZone, string> = {
-  main_dining: 'bg-lundies-sand/20 text-lundies-sand dark:bg-lundies-sand/10 dark:text-lundies-sand',
-  window: 'bg-sky-100 text-sky-700 dark:bg-sky-900/60 dark:text-sky-200',
-  private: 'bg-lundies-peat/20 text-lundies-peat dark:bg-lundies-peat/10 dark:text-lundies-peat',
-  terrace: 'bg-lundies-heather/20 text-lundies-heather dark:bg-lundies-heather/10 dark:text-lundies-heather',
-  chef_counter: 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/60 dark:text-indigo-200',
+  main_dining: 'bg-lundies-sand/30 text-lundies-peat dark:bg-neutral-900/60 dark:text-neutral-200',
+  window: 'bg-lundies-linen/70 text-lundies-peat dark:bg-neutral-900/60 dark:text-neutral-200',
+  private: 'bg-lundies-stone/50 text-lundies-charcoal dark:bg-neutral-900/60 dark:text-neutral-200',
+  terrace: 'bg-lundies-heather/40 text-lundies-moss dark:bg-neutral-900/60 dark:text-neutral-200',
+  chef_counter: 'bg-lundies-peat/30 text-lundies-charcoal dark:bg-neutral-900/60 dark:text-neutral-200',
 }
 
 type ZoneBackground = {
@@ -49,7 +49,7 @@ const zoneBackgrounds: ZoneBackground[] = [
   {
     zone: 'window',
     style: { left: '0%', top: '0%', width: '42%', height: '48%' },
-    className: 'bg-sky-200/30 dark:bg-sky-900/30 border-sky-400/60',
+    className: 'bg-lundies-linen/60 border-lundies-stone/60 dark:bg-neutral-900/50 dark:border-neutral-700',
   },
   {
     zone: 'main_dining',
@@ -69,7 +69,7 @@ const zoneBackgrounds: ZoneBackground[] = [
   {
     zone: 'chef_counter',
     style: { left: '72%', top: '58%', width: '24%', height: '28%' },
-    className: 'bg-indigo-200/30 dark:bg-indigo-900/30 border-indigo-400/60',
+    className: 'bg-lundies-peat/40 border-lundies-charcoal/50 dark:bg-neutral-900/60 dark:border-neutral-700',
   },
 ]
 
@@ -749,7 +749,7 @@ export default function RestaurantGuestExperience() {
                     <span className="h-3 w-3 rounded-full bg-lundies-stone" /> Unavailable this slot
                   </span>
                   <span className="flex items-center gap-2">
-                    <span className="h-3 w-3 rounded-full bg-indigo-500" /> Accessibility icons
+                    <span className="h-3 w-3 rounded-full bg-lundies-moss" /> Accessibility icons
                   </span>
                 </div>
                 <div className="flex items-center gap-2">
@@ -854,7 +854,7 @@ export default function RestaurantGuestExperience() {
                                 {formatZoneLabel(table.zone)}
                               </span>
                               {accessibilityBadges.length > 0 && (
-                                <div className="mt-1 flex gap-1 text-[11px] text-indigo-600 dark:text-indigo-200">
+                                <div className="mt-1 flex gap-1 text-[11px] text-lundies-moss dark:text-neutral-200">
                                   {accessibilityBadges.map((item) => (
                                     <span key={`${table.id}-${item.label}`} title={item.label} aria-label={item.label}>
                                       {item.icon}
@@ -959,11 +959,11 @@ export default function RestaurantGuestExperience() {
                           ))}
                         </div>
                         {selectedTable.accessibility.length > 0 && (
-                          <div className="flex flex-wrap gap-2 text-[11px] text-indigo-600 dark:text-indigo-200">
+                          <div className="flex flex-wrap gap-2 text-[11px] text-lundies-moss dark:text-neutral-200">
                             {selectedTable.accessibility.map((item) => (
                               <span
                                 key={`${selectedTable.id}-${item}`}
-                                className="flex items-center gap-1 rounded-full bg-indigo-50 px-2 py-0.5 dark:bg-indigo-900/40"
+                                className="flex items-center gap-1 rounded-full bg-lundies-heather/20 px-2 py-0.5 dark:bg-neutral-900/50"
                               >
                                 <span aria-hidden="true">{accessibilityIcons[item].icon}</span>
                                 <span>{accessibilityMap.get(item)}</span>
@@ -981,7 +981,7 @@ export default function RestaurantGuestExperience() {
                         )}
                         {!tableIsAvailable && (
                           <p className="text-xs text-lundies-sand dark:text-lundies-sand">
-                            This table is linked to another reservation right now. Choose any table highlighted in emerald to proceed.
+                            This table is linked to another reservation right now. Choose any table highlighted in moss tones to proceed.
                           </p>
                         )}
                       </div>
@@ -1026,7 +1026,7 @@ export default function RestaurantGuestExperience() {
                               {canReserve ? 'Provide guest details' : 'Select an available table'}
                             </button>
                             <p className="text-xs text-lundies-stone dark:text-lundies-stone">
-                              Secure your table in a few steps — we'll capture dietary needs, special occasions, and contact details next.
+                              Secure your table in a few steps — we&apos;ll capture dietary needs, special occasions, and contact details next.
                             </p>
                           </>
                         ) : (
@@ -1091,7 +1091,7 @@ export default function RestaurantGuestExperience() {
                         <span>Updated {formatIsoTime(slot.lastUpdated)}</span>
                       </div>
                       {slot.specialEvent && (
-                        <p className="mt-2 text-xs text-emerald-600 dark:text-emerald-300">
+                        <p className="mt-2 text-xs text-lundies-moss dark:text-neutral-300">
                           {slotEventIcon[slot.specialEvent.tone]} {slot.specialEvent.label}
                         </p>
                       )}

--- a/src/components/StaffLogin.tsx
+++ b/src/components/StaffLogin.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import Link from 'next/link'
+import { useCallback, useEffect, useState } from 'react'
 import { useAuth } from '@/context/AuthContext'
 import { useRouter } from 'next/navigation'
 
@@ -11,33 +12,28 @@ export default function StaffLogin() {
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(false)
   const [showTwoFactor, setShowTwoFactor] = useState(false)
-  const [sessionTimeout, setSessionTimeout] = useState<NodeJS.Timeout | null>(null)
-
   const { login, user, userProfile, logout } = useAuth()
   const router = useRouter()
+
+  const handleSessionTimeout = useCallback(async () => {
+    setError('Session expired for security. Please log in again.')
+    await logout()
+    router.push('/admin/login')
+  }, [logout, router])
 
   // Session timeout management (30 minutes for staff)
   useEffect(() => {
     if (user && userProfile && ['staff', 'manager', 'admin'].includes(userProfile.role)) {
       const timeout = setTimeout(() => {
         handleSessionTimeout()
-      }, 30 * 60 * 1000) // 30 minutes
-
-      setSessionTimeout(timeout as unknown as number)
+      }, 30 * 60 * 1000)
 
       return () => {
-        if (timeout) {
-          clearTimeout(timeout)
-        }
+        clearTimeout(timeout)
       }
     }
-  }, [user, userProfile])
-
-  const handleSessionTimeout = async () => {
-    setError('Session expired for security. Please log in again.')
-    await logout()
-    router.push('/admin/login')
-  }
+    return undefined
+  }, [handleSessionTimeout, user, userProfile])
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -118,29 +114,29 @@ export default function StaffLogin() {
 
   if (showTwoFactor) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-indigo-50 to-blue-100 dark:from-gray-900 dark:to-gray-800">
-        <div className="max-w-md w-full mx-auto p-6 bg-white rounded-lg shadow-lg dark:bg-gray-800">
-          <div className="text-center mb-6">
-            <div className="mx-auto h-12 w-12 bg-indigo-100 rounded-full flex items-center justify-center">
-              <svg className="h-6 w-6 text-indigo-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-lundies-ivory via-lundies-linen to-lundies-stone dark:from-neutral-950 dark:via-neutral-900 dark:to-neutral-800">
+        <div className="mx-auto w-full max-w-md rounded-3xl border border-lundies-stone/60 bg-white/80 p-6 shadow-lg backdrop-blur-sm dark:border-neutral-700 dark:bg-neutral-900/80">
+          <div className="mb-6 space-y-3 text-center">
+            <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-lundies-linen/80">
+              <svg className="h-6 w-6 text-lundies-moss" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
               </svg>
             </div>
-            <h2 className="text-2xl font-bold text-gray-900 dark:text-white">Two-Factor Authentication</h2>
-            <p className="text-gray-600 dark:text-gray-400 text-sm mt-2">
+            <h2 className="text-2xl font-bold text-lundies-charcoal dark:text-neutral-50">Two-Factor Authentication</h2>
+            <p className="mt-2 text-sm text-lundies-peat/80 dark:text-neutral-300">
               Enter the 6-digit code sent to your device
             </p>
           </div>
 
           {error && (
-            <div className="mb-4 p-3 bg-red-100 border border-red-400 text-red-700 rounded">
+            <div className="mb-4 rounded-lg border border-lundies-peat/30 bg-lundies-peat/10 p-3 text-lundies-peat dark:border-neutral-600 dark:bg-neutral-800">
               {error}
             </div>
           )}
 
           <form onSubmit={handleTwoFactorSubmit} className="space-y-4">
             <div>
-              <label htmlFor="twoFactorCode" className="block text-sm font-medium mb-1">
+              <label htmlFor="twoFactorCode" className="mb-1 block text-sm font-medium text-lundies-charcoal dark:text-neutral-100">
                 Verification Code
               </label>
               <input
@@ -148,7 +144,7 @@ export default function StaffLogin() {
                 id="twoFactorCode"
                 value={twoFactorCode}
                 onChange={(e) => setTwoFactorCode(e.target.value.replace(/\D/g, '').slice(0, 6))}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:bg-gray-700 dark:border-gray-600 text-center text-lg tracking-widest"
+                className="w-full rounded-lg border border-lundies-stone/50 px-3 py-2 text-center text-lg tracking-widest text-lundies-charcoal focus:outline-none focus:ring-2 focus:ring-lundies-moss dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100"
                 placeholder="000000"
                 maxLength={6}
                 required
@@ -158,7 +154,7 @@ export default function StaffLogin() {
             <button
               type="submit"
               disabled={loading || twoFactorCode.length !== 6}
-              className="w-full py-2 px-4 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-50"
+              className="w-full rounded-lg bg-lundies-moss px-4 py-2 font-medium text-white transition hover:bg-lundies-heather focus:outline-none focus:ring-2 focus:ring-lundies-moss disabled:opacity-50"
             >
               {loading ? 'Verifying...' : 'Verify & Continue'}
             </button>
@@ -167,9 +163,9 @@ export default function StaffLogin() {
           <div className="mt-4 text-center">
             <button
               onClick={resendTwoFactorCode}
-              className="text-indigo-600 hover:text-indigo-800 text-sm"
+              className="text-sm font-medium text-lundies-moss hover:text-lundies-heather"
             >
-              Didn't receive a code? Resend
+              Didn&apos;t receive a code? Resend
             </button>
           </div>
 
@@ -180,7 +176,7 @@ export default function StaffLogin() {
                 setTwoFactorCode('')
                 setError('')
               }}
-              className="text-gray-600 hover:text-gray-800 text-sm"
+              className="text-sm text-lundies-peat hover:text-lundies-charcoal"
             >
               ← Back to login
             </button>
@@ -191,29 +187,29 @@ export default function StaffLogin() {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-indigo-50 to-blue-100 dark:from-gray-900 dark:to-gray-800">
-      <div className="max-w-md w-full mx-auto p-6 bg-white rounded-lg shadow-lg dark:bg-gray-800">
-        <div className="text-center mb-6">
-          <div className="mx-auto h-12 w-12 bg-indigo-100 rounded-full flex items-center justify-center">
-            <svg className="h-6 w-6 text-indigo-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-lundies-ivory via-lundies-linen to-lundies-stone dark:from-neutral-950 dark:via-neutral-900 dark:to-neutral-800">
+      <div className="mx-auto w-full max-w-md rounded-3xl border border-lundies-stone/60 bg-white/80 p-6 shadow-lg backdrop-blur-sm dark:border-neutral-700 dark:bg-neutral-900/80">
+        <div className="mb-6 space-y-3 text-center">
+          <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-lundies-linen/80">
+            <svg className="h-6 w-6 text-lundies-moss" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" />
             </svg>
           </div>
-          <h2 className="text-2xl font-bold text-gray-900 dark:text-white">Staff Portal</h2>
-          <p className="text-gray-600 dark:text-gray-400 text-sm">
+          <h2 className="text-2xl font-bold text-lundies-charcoal dark:text-neutral-50">Staff Portal</h2>
+          <p className="text-sm text-lundies-peat/80 dark:text-neutral-300">
             Secure access for hotel staff and management
           </p>
         </div>
 
         {error && (
-          <div className="mb-4 p-3 bg-red-100 border border-red-400 text-red-700 rounded">
+          <div className="mb-4 rounded-lg border border-lundies-peat/30 bg-lundies-peat/10 p-3 text-lundies-peat dark:border-neutral-600 dark:bg-neutral-800">
             {error}
           </div>
         )}
 
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
-            <label htmlFor="email" className="block text-sm font-medium mb-1">
+            <label htmlFor="email" className="mb-1 block text-sm font-medium text-lundies-charcoal dark:text-neutral-100">
               Staff Email
             </label>
             <input
@@ -221,14 +217,14 @@ export default function StaffLogin() {
               id="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:bg-gray-700 dark:border-gray-600"
+              className="w-full rounded-lg border border-lundies-stone/50 px-3 py-2 text-lundies-charcoal focus:outline-none focus:ring-2 focus:ring-lundies-moss dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100"
               placeholder="staff@hotel.com"
               required
             />
           </div>
 
           <div>
-            <label htmlFor="password" className="block text-sm font-medium mb-1">
+            <label htmlFor="password" className="mb-1 block text-sm font-medium text-lundies-charcoal dark:text-neutral-100">
               Password
             </label>
             <input
@@ -236,7 +232,7 @@ export default function StaffLogin() {
               id="password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:bg-gray-700 dark:border-gray-600"
+              className="w-full rounded-lg border border-lundies-stone/50 px-3 py-2 text-lundies-charcoal focus:outline-none focus:ring-2 focus:ring-lundies-moss dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100"
               required
             />
           </div>
@@ -244,35 +240,32 @@ export default function StaffLogin() {
           <button
             type="submit"
             disabled={loading}
-            className="w-full py-2 px-4 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-50"
+            className="w-full rounded-lg bg-lundies-moss px-4 py-2 font-medium text-white transition hover:bg-lundies-heather focus:outline-none focus:ring-2 focus:ring-lundies-moss disabled:opacity-50"
           >
             {loading ? 'Signing In...' : 'Sign In'}
           </button>
         </form>
 
         <div className="mt-6 text-center">
-          <div className="flex items-center justify-center space-x-2 text-sm text-gray-600 dark:text-gray-400">
-            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <div className="flex items-center justify-center space-x-2 text-sm text-lundies-peat/80 dark:text-neutral-300">
+            <svg className="h-4 w-4 text-lundies-moss" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
             </svg>
             <span>Secured with 2FA</span>
           </div>
         </div>
 
-        <div className="mt-4 text-center">
-          <a
-            href="/"
-            className="text-indigo-600 hover:text-indigo-800 text-sm"
-          >
-            ← Back to main site
-          </a>
-        </div>
+          <div className="mt-4 text-center">
+            <Link href="/" className="text-sm font-medium text-lundies-moss hover:text-lundies-heather">
+              ← Back to main site
+            </Link>
+          </div>
 
         {/* Demo credentials info */}
-        <div className="mt-6 p-3 bg-yellow-50 border border-yellow-200 rounded text-sm">
-          <p className="font-medium text-yellow-800">Demo Credentials:</p>
-          <p className="text-yellow-700">Use any email with 'staff', 'manager', or 'admin' to trigger 2FA</p>
-          <p className="text-yellow-700">2FA Code: 123456 (for demo)</p>
+        <div className="mt-6 rounded-xl border border-lundies-stone/60 bg-lundies-linen/80 p-3 text-sm text-lundies-peat dark:border-neutral-700 dark:bg-neutral-900/70 dark:text-neutral-200">
+          <p className="font-medium text-lundies-charcoal dark:text-neutral-100">Demo Credentials:</p>
+            <p>Use any email with &lsquo;staff&rsquo;, &lsquo;manager&rsquo;, or &lsquo;admin&rsquo; to trigger 2FA</p>
+          <p>2FA Code: 123456 (for demo)</p>
         </div>
       </div>
     </div>

--- a/src/components/admin/AdminNav.tsx
+++ b/src/components/admin/AdminNav.tsx
@@ -32,35 +32,37 @@ export default function AdminNav({ className = '' }: AdminNavProps) {
   ];
 
   return (
-    <nav className={`bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-4 ${className}`}>
-      <div className="flex items-center justify-between mb-4">
-        <h2 className="text-lg font-semibold text-gray-900 dark:text-white flex items-center">
-          <span className="w-8 h-8 bg-blue-100 dark:bg-blue-900 rounded-lg flex items-center justify-center mr-3 text-sm">
+    <nav
+      className={`rounded-3xl border border-lundies-stone/60 bg-white/70 p-4 shadow-sm backdrop-blur-sm dark:border-neutral-700 dark:bg-neutral-900/70 ${className}`}
+    >
+      <div className="mb-4 flex items-center justify-between">
+        <h2 className="flex items-center text-lg font-semibold text-lundies-charcoal dark:text-neutral-100">
+          <span className="mr-3 flex h-8 w-8 items-center justify-center rounded-lg bg-lundies-linen/80 text-sm text-lundies-charcoal shadow-sm dark:bg-neutral-800 dark:text-neutral-100">
             ⚙️
           </span>
           Admin Panel
         </h2>
       </div>
-      
+
       <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
         {navItems.map((item) => {
           const isActive = pathname === item.href;
-          
+
           return (
             <Link
               key={item.href}
               href={item.href}
-              className={`p-4 rounded-lg border transition-colors ${
+              className={`rounded-2xl border p-4 transition-colors ${
                 isActive
-                  ? 'bg-blue-50 border-blue-200 text-blue-900 dark:bg-blue-900/20 dark:border-blue-700 dark:text-blue-300'
-                  : 'bg-gray-50 border-gray-200 text-gray-700 hover:bg-gray-100 dark:bg-gray-700 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-600'
+                  ? 'border-lundies-stone/60 bg-lundies-linen/90 text-lundies-charcoal shadow-sm dark:border-neutral-600 dark:bg-neutral-800'
+                  : 'border-lundies-stone/40 bg-white/70 text-lundies-peat/80 hover:bg-lundies-ivory/80 dark:border-neutral-700 dark:bg-neutral-900/70 dark:text-neutral-200 dark:hover:bg-neutral-800'
               }`}
             >
-              <div className="flex items-center mb-2">
-                <span className="text-2xl mr-3">{item.icon}</span>
+              <div className="mb-2 flex items-center text-lundies-charcoal dark:text-neutral-100">
+                <span className="mr-3 text-2xl">{item.icon}</span>
                 <span className="font-medium">{item.label}</span>
               </div>
-              <p className="text-sm opacity-75">{item.description}</p>
+              <p className="text-sm text-lundies-peat/80 dark:text-neutral-300">{item.description}</p>
             </Link>
           );
         })}

--- a/src/components/restaurant/WaitlistPanel.tsx
+++ b/src/components/restaurant/WaitlistPanel.tsx
@@ -123,41 +123,41 @@ export function WaitlistPanel({
   if (submittedRecord) {
     const { formValues } = submittedRecord
     return (
-      <div className="mt-6 space-y-5 rounded-2xl border border-emerald-300 bg-emerald-50/70 p-6 text-sm text-emerald-800 shadow-sm dark:border-emerald-500/40 dark:bg-emerald-900/20 dark:text-emerald-100">
+      <div className="mt-6 space-y-5 rounded-2xl border border-lundies-moss/60 bg-lundies-heather/30 p-6 text-sm text-lundies-moss shadow-sm dark:border-lundies-moss/60 dark:bg-neutral-900/40 dark:text-neutral-200">
         <header className="space-y-2 text-center">
-          <div className="inline-flex items-center gap-2 rounded-full bg-emerald-100 px-4 py-1 text-sm font-semibold text-emerald-700 dark:bg-emerald-500/30 dark:text-emerald-200">
+          <div className="inline-flex items-center gap-2 rounded-full bg-lundies-heather/40 px-4 py-1 text-sm font-semibold text-lundies-moss dark:bg-neutral-900/50 dark:text-neutral-200">
             Waitlist spot secured
           </div>
-          <p className="text-base font-semibold text-emerald-900 dark:text-emerald-100">
-            Thanks {formValues.fullName.split(' ')[0] || formValues.fullName}, you’re number {queuePosition} in line.
+          <p className="text-base font-semibold text-lundies-moss dark:text-neutral-200">
+            Thanks {formValues.fullName.split(' ')[0] || formValues.fullName}, you&apos;re number {queuePosition} in line.
           </p>
-          <p className="text-xs text-emerald-700/90 dark:text-emerald-100/80">
-            We’ll notify you via {formValues.notificationPreference === 'both' ? 'email and SMS' : formValues.notificationPreference}.
-            Once a table opens you’ll have {acceptanceMinutes} minutes to confirm before we contact the next guest.
+          <p className="text-xs text-lundies-moss/90 dark:text-neutral-200/80">
+            We&apos;ll notify you via {formValues.notificationPreference === 'both' ? 'email and SMS' : formValues.notificationPreference}.
+            Once a table opens you&apos;ll have {acceptanceMinutes} minutes to confirm before we contact the next guest.
           </p>
         </header>
-        <dl className="grid gap-3 rounded-xl border border-emerald-200 bg-white/90 p-4 text-emerald-800 dark:border-emerald-500/40 dark:bg-emerald-950/40 dark:text-emerald-100 md:grid-cols-2">
+        <dl className="grid gap-3 rounded-xl border border-lundies-moss/50 bg-white/90 p-4 text-lundies-moss dark:border-lundies-moss/60 dark:bg-neutral-900/50 dark:text-neutral-200 md:grid-cols-2">
           <div>
-            <dt className="text-xs font-semibold uppercase tracking-wide text-emerald-600 dark:text-emerald-200">Party size</dt>
+            <dt className="text-xs font-semibold uppercase tracking-wide text-lundies-moss dark:text-neutral-200">Party size</dt>
             <dd className="mt-1 text-sm">{formValues.partySize} guest{formValues.partySize > 1 ? 's' : ''}</dd>
           </div>
           <div>
-            <dt className="text-xs font-semibold uppercase tracking-wide text-emerald-600 dark:text-emerald-200">Estimated wait</dt>
+            <dt className="text-xs font-semibold uppercase tracking-wide text-lundies-moss dark:text-neutral-200">Estimated wait</dt>
             <dd className="mt-1 text-sm">Approximately {estimatedWaitMinutes} minutes</dd>
           </div>
           <div>
-            <dt className="text-xs font-semibold uppercase tracking-wide text-emerald-600 dark:text-emerald-200">Contact</dt>
+            <dt className="text-xs font-semibold uppercase tracking-wide text-lundies-moss dark:text-neutral-200">Contact</dt>
             <dd className="mt-1 text-sm space-y-1">
               <p>{formValues.email}</p>
               <p>{formValues.phone}</p>
             </dd>
           </div>
           <div>
-            <dt className="text-xs font-semibold uppercase tracking-wide text-emerald-600 dark:text-emerald-200">Notes</dt>
+            <dt className="text-xs font-semibold uppercase tracking-wide text-lundies-moss dark:text-neutral-200">Notes</dt>
             <dd className="mt-1 text-sm">{formValues.notes ?? 'No additional notes provided.'}</dd>
           </div>
         </dl>
-        <section className="space-y-2 text-xs text-emerald-700/90 dark:text-emerald-100/80">
+        <section className="space-y-2 text-xs text-lundies-moss/90 dark:text-neutral-200/80">
           <p>
             Our host desk monitors the list continuously. Expect an update as soon as the current guests depart or a cancellation arrives.
             If your plans change, please remove yourself via the confirmation link so we can assist other diners.
@@ -165,7 +165,7 @@ export function WaitlistPanel({
           <button
             type="button"
             onClick={handleJoinAnother}
-            className="inline-flex items-center justify-center rounded-lg border border-emerald-500 px-4 py-2 text-sm font-semibold text-emerald-700 transition hover:bg-emerald-100 dark:border-emerald-400 dark:text-emerald-200 dark:hover:bg-emerald-900/40"
+            className="inline-flex items-center justify-center rounded-lg border border-lundies-moss px-4 py-2 text-sm font-semibold text-lundies-moss transition hover:bg-lundies-heather/40 dark:border-lundies-moss/70 dark:text-neutral-200 dark:hover:bg-neutral-900/50"
           >
             Join with different details
           </button>
@@ -175,22 +175,22 @@ export function WaitlistPanel({
   }
 
   return (
-    <div className="mt-6 space-y-6 rounded-2xl border border-amber-200 bg-amber-50 p-6 text-sm text-amber-800 shadow-sm dark:border-amber-500/40 dark:bg-amber-900/20 dark:text-amber-100">
+    <div className="mt-6 space-y-6 rounded-2xl border border-lundies-sand/50 bg-lundies-sand/20 p-6 text-sm text-lundies-peat shadow-sm dark:border-lundies-sand/50 dark:bg-neutral-900/40 dark:text-neutral-200">
       <header className="space-y-2">
-        <div className="inline-flex items-center gap-2 rounded-full bg-amber-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-amber-700 dark:bg-amber-500/20 dark:text-amber-200">
+        <div className="inline-flex items-center gap-2 rounded-full bg-lundies-sand/30 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-lundies-peat dark:bg-neutral-900/50 dark:text-neutral-200">
           Fully booked · Join waitlist
         </div>
-        <h3 className="text-xl font-semibold text-amber-900 dark:text-amber-100">
+        <h3 className="text-xl font-semibold text-lundies-peat dark:text-neutral-200">
           Position {queuePosition} · Estimated wait {estimatedWaitMinutes} minutes
         </h3>
-        <p className="text-xs text-amber-700/90 dark:text-amber-200/80">
-          We’ll hold your place and notify you automatically. Once contacted you’ll have {acceptanceMinutes} minutes to accept before we offer the table to the next guest.
+        <p className="text-xs text-lundies-peat/90 dark:text-neutral-200/80">
+          We&apos;ll hold your place and notify you automatically. Once contacted you&apos;ll have {acceptanceMinutes} minutes to accept before we offer the table to the next guest.
         </p>
       </header>
 
       <form onSubmit={onFormSubmit} className="space-y-5">
         <div>
-          <label className="block text-sm font-medium text-amber-900 dark:text-amber-100" htmlFor="waitlist-fullName">
+          <label className="block text-sm font-medium text-lundies-peat dark:text-neutral-200" htmlFor="waitlist-fullName">
             Full name
           </label>
           <input
@@ -201,14 +201,14 @@ export function WaitlistPanel({
               minLength: { value: 2, message: 'Enter the name we should call when your table is ready.' },
               maxLength: { value: 120, message: 'Name must be 120 characters or fewer.' },
             })}
-            className="mt-2 w-full rounded-lg border border-amber-300 bg-white px-3 py-2 text-sm text-amber-900 shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500 dark:border-amber-500/40 dark:bg-amber-950/50 dark:text-amber-50"
+            className="mt-2 w-full rounded-lg border border-lundies-sand/60 bg-white px-3 py-2 text-sm text-lundies-peat shadow-sm focus:border-lundies-moss focus:outline-none focus:ring-2 focus:ring-lundies-moss dark:border-lundies-sand/50 dark:bg-neutral-900/60 dark:text-neutral-200"
             placeholder="Who should we call?"
           />
-          {errors.fullName && <p className="mt-1 text-sm text-rose-600 dark:text-rose-300">{errors.fullName.message}</p>}
+          {errors.fullName && <p className="mt-1 text-sm text-lundies-peat dark:text-neutral-200">{errors.fullName.message}</p>}
         </div>
         <div className="grid gap-4 sm:grid-cols-2">
           <div>
-            <label className="block text-sm font-medium text-amber-900 dark:text-amber-100" htmlFor="waitlist-email">
+            <label className="block text-sm font-medium text-lundies-peat dark:text-neutral-200" htmlFor="waitlist-email">
               Email address
             </label>
             <input
@@ -222,13 +222,13 @@ export function WaitlistPanel({
                   message: 'Enter a valid email so we can send confirmation.',
                 },
               })}
-              className="mt-2 w-full rounded-lg border border-amber-300 bg-white px-3 py-2 text-sm text-amber-900 shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500 dark:border-amber-500/40 dark:bg-amber-950/50 dark:text-amber-50"
+              className="mt-2 w-full rounded-lg border border-lundies-sand/60 bg-white px-3 py-2 text-sm text-lundies-peat shadow-sm focus:border-lundies-moss focus:outline-none focus:ring-2 focus:ring-lundies-moss dark:border-lundies-sand/50 dark:bg-neutral-900/60 dark:text-neutral-200"
               placeholder="guest@example.com"
             />
-            {errors.email && <p className="mt-1 text-sm text-rose-600 dark:text-rose-300">{errors.email.message}</p>}
+            {errors.email && <p className="mt-1 text-sm text-lundies-peat dark:text-neutral-200">{errors.email.message}</p>}
           </div>
           <div>
-            <label className="block text-sm font-medium text-amber-900 dark:text-amber-100" htmlFor="waitlist-phone">
+            <label className="block text-sm font-medium text-lundies-peat dark:text-neutral-200" htmlFor="waitlist-phone">
               Mobile number
             </label>
             <input
@@ -239,17 +239,17 @@ export function WaitlistPanel({
                 minLength: { value: 6, message: 'Enter a contact number we can text or call.' },
                 maxLength: { value: 24, message: 'Phone numbers are limited to 24 characters.' },
               })}
-              className="mt-2 w-full rounded-lg border border-amber-300 bg-white px-3 py-2 text-sm text-amber-900 shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500 dark:border-amber-500/40 dark:bg-amber-950/50 dark:text-amber-50"
-              placeholder="We’ll send SMS alerts here"
+              className="mt-2 w-full rounded-lg border border-lundies-sand/60 bg-white px-3 py-2 text-sm text-lundies-peat shadow-sm focus:border-lundies-moss focus:outline-none focus:ring-2 focus:ring-lundies-moss dark:border-lundies-sand/50 dark:bg-neutral-900/60 dark:text-neutral-200"
+            placeholder="We&apos;ll send SMS alerts here"
             />
-            {errors.phone && <p className="mt-1 text-sm text-rose-600 dark:text-rose-300">{errors.phone.message}</p>}
+            {errors.phone && <p className="mt-1 text-sm text-lundies-peat dark:text-neutral-200">{errors.phone.message}</p>}
           </div>
         </div>
         <div>
-          <label className="block text-sm font-medium text-amber-900 dark:text-amber-100" htmlFor="waitlist-partySize">
+          <label className="block text-sm font-medium text-lundies-peat dark:text-neutral-200" htmlFor="waitlist-partySize">
             Party size
           </label>
-          <p className="text-xs text-amber-700/90 dark:text-amber-200/80">
+          <p className="text-xs text-lundies-peat/90 dark:text-neutral-200/80">
             We can seat parties between {minGuests} and {maxGuests} guests when a table frees up.
           </p>
           <select
@@ -260,7 +260,7 @@ export function WaitlistPanel({
               min: { value: minGuests, message: `We can only waitlist parties of ${minGuests} or more.` },
               max: { value: maxGuests, message: `The maximum party size for this waitlist is ${maxGuests}.` },
             })}
-            className="mt-2 w-full rounded-lg border border-amber-300 bg-white px-3 py-2 text-sm text-amber-900 shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500 dark:border-amber-500/40 dark:bg-amber-950/50 dark:text-amber-50"
+            className="mt-2 w-full rounded-lg border border-lundies-sand/60 bg-white px-3 py-2 text-sm text-lundies-peat shadow-sm focus:border-lundies-moss focus:outline-none focus:ring-2 focus:ring-lundies-moss dark:border-lundies-sand/50 dark:bg-neutral-900/60 dark:text-neutral-200"
           >
             {guestRange.map((value) => (
               <option key={value} value={value}>
@@ -268,15 +268,15 @@ export function WaitlistPanel({
               </option>
             ))}
           </select>
-          {errors.partySize && <p className="mt-1 text-sm text-rose-600 dark:text-rose-300">{errors.partySize.message}</p>}
+          {errors.partySize && <p className="mt-1 text-sm text-lundies-peat dark:text-neutral-200">{errors.partySize.message}</p>}
         </div>
         <fieldset className="space-y-3">
-          <legend className="text-sm font-medium text-amber-900 dark:text-amber-100">How should we notify you?</legend>
+          <legend className="text-sm font-medium text-lundies-peat dark:text-neutral-200">How should we notify you?</legend>
           <div className="grid gap-2 sm:grid-cols-3">
             {waitlistNotificationOptions.map((option) => (
               <label
                 key={option.value}
-                className="flex cursor-pointer items-start gap-2 rounded-lg border border-amber-200 bg-white px-3 py-2 text-sm text-amber-700 transition hover:border-emerald-400 hover:bg-emerald-50/50 dark:border-amber-500/40 dark:bg-amber-950/50 dark:text-amber-100 dark:hover:border-emerald-500"
+                className="flex cursor-pointer items-start gap-2 rounded-lg border border-lundies-sand/50 bg-white px-3 py-2 text-sm text-lundies-peat transition hover:border-lundies-moss/80 hover:bg-lundies-heather/20 dark:border-lundies-sand/50 dark:bg-neutral-900/60 dark:text-neutral-200 dark:hover:border-lundies-moss"
               >
                 <input
                   type="radio"
@@ -284,21 +284,21 @@ export function WaitlistPanel({
                   {...register('notificationPreference', {
                     required: 'Select how we should notify you.',
                   })}
-                  className="mt-1 h-4 w-4 border-amber-300 text-emerald-600 focus:ring-emerald-500 dark:border-amber-400 dark:bg-amber-950"
+                  className="mt-1 h-4 w-4 border-lundies-sand/60 text-lundies-moss focus:ring-lundies-moss dark:border-neutral-700 dark:bg-neutral-900/60"
                 />
                 <span>
-                  <span className="block font-semibold text-amber-900 dark:text-amber-100">{option.label}</span>
-                  <span className="text-xs text-amber-700/90 dark:text-amber-200/80">{option.description}</span>
+                  <span className="block font-semibold text-lundies-peat dark:text-neutral-200">{option.label}</span>
+                  <span className="text-xs text-lundies-peat/90 dark:text-neutral-200/80">{option.description}</span>
                 </span>
               </label>
             ))}
           </div>
           {errors.notificationPreference && (
-            <p className="text-sm text-rose-600 dark:text-rose-300">{errors.notificationPreference.message}</p>
+            <p className="text-sm text-lundies-peat dark:text-neutral-200">{errors.notificationPreference.message}</p>
           )}
         </fieldset>
         <div>
-          <label className="block text-sm font-medium text-amber-900 dark:text-amber-100" htmlFor="waitlist-notes">
+          <label className="block text-sm font-medium text-lundies-peat dark:text-neutral-200" htmlFor="waitlist-notes">
             Notes for the host (optional)
           </label>
           <textarea
@@ -307,13 +307,13 @@ export function WaitlistPanel({
             {...register('notes', {
               maxLength: { value: 240, message: 'Notes must be 240 characters or fewer.' },
             })}
-            className="mt-2 w-full rounded-lg border border-amber-300 bg-white px-3 py-2 text-sm text-amber-900 shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500 dark:border-amber-500/40 dark:bg-amber-950/50 dark:text-amber-50"
+            className="mt-2 w-full rounded-lg border border-lundies-sand/60 bg-white px-3 py-2 text-sm text-lundies-peat shadow-sm focus:border-lundies-moss focus:outline-none focus:ring-2 focus:ring-lundies-moss dark:border-lundies-sand/50 dark:bg-neutral-900/60 dark:text-neutral-200"
             placeholder="Share accessibility needs or timing preferences."
           />
-          {errors.notes && <p className="mt-1 text-sm text-rose-600 dark:text-rose-300">{errors.notes.message}</p>}
+          {errors.notes && <p className="mt-1 text-sm text-lundies-peat dark:text-neutral-200">{errors.notes.message}</p>}
         </div>
-        <section className="space-y-2 rounded-xl border border-amber-200 bg-white px-4 py-3 text-xs text-amber-700 dark:border-amber-500/40 dark:bg-amber-950/40 dark:text-amber-100">
-          <p className="font-semibold text-amber-900 dark:text-amber-100">Waitlist essentials</p>
+        <section className="space-y-2 rounded-xl border border-lundies-sand/50 bg-white px-4 py-3 text-xs text-lundies-peat dark:border-neutral-700 dark:bg-neutral-900/60 dark:text-neutral-200">
+          <p className="font-semibold text-lundies-peat dark:text-neutral-200">Waitlist essentials</p>
           <ul className="list-disc space-y-1 pl-5">
             <li>Notifications are automatic — confirm within {acceptanceMinutes} minutes to secure the table.</li>
             <li>Missed responses move the booking to the next guest but you remain on standby.</li>
@@ -325,36 +325,36 @@ export function WaitlistPanel({
               {...register('acceptTerms', {
                 validate: (value: boolean) => value || 'Please agree to the waitlist terms.',
               })}
-              className="mt-1 h-4 w-4 rounded border-amber-300 text-emerald-600 focus:ring-emerald-500 dark:border-amber-400 dark:bg-amber-950"
+              className="mt-1 h-4 w-4 rounded border-lundies-sand/60 text-lundies-moss focus:ring-lundies-moss dark:border-neutral-700 dark:bg-neutral-900/60"
             />
             <span>I understand the waitlist terms and will confirm promptly when contacted.</span>
           </label>
-          {errors.acceptTerms && <p className="text-sm text-rose-600 dark:text-rose-300">{errors.acceptTerms.message}</p>}
+          {errors.acceptTerms && <p className="text-sm text-lundies-peat dark:text-neutral-200">{errors.acceptTerms.message}</p>}
         </section>
         <div className="flex flex-col gap-4">
           <button
             type="submit"
             disabled={isSubmitting}
-            className="inline-flex items-center justify-center rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-500 disabled:cursor-not-allowed disabled:bg-emerald-400"
+            className="inline-flex items-center justify-center rounded-lg bg-lundies-moss px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-lundies-heather focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-lundies-moss disabled:cursor-not-allowed disabled:bg-lundies-heather"
           >
             {isSubmitting ? 'Adding to waitlist…' : 'Join the waitlist'}
           </button>
-          <div className="rounded-xl border border-amber-200 bg-white px-4 py-3 text-xs text-amber-700 dark:border-amber-500/40 dark:bg-amber-950/40 dark:text-amber-100">
-            <p className="font-semibold text-amber-900 dark:text-amber-100">Alternative times with availability</p>
+          <div className="rounded-xl border border-lundies-sand/50 bg-white px-4 py-3 text-xs text-lundies-peat dark:border-neutral-700 dark:bg-neutral-900/60 dark:text-neutral-200">
+            <p className="font-semibold text-lundies-peat dark:text-neutral-200">Alternative times with availability</p>
             {alternativeSlots.length === 0 ? (
-              <p className="mt-2">We’ll email you other dates as soon as new tables open.</p>
+              <p className="mt-2">We&apos;ll email you other dates as soon as new tables open.</p>
             ) : (
               <ul className="mt-2 space-y-2">
                 {alternativeSlots.map((slot) => (
                   <li key={slot.id} className="flex flex-wrap items-center justify-between gap-2">
                     <div>
-                      <p className="text-sm font-semibold text-amber-900 dark:text-amber-100">{slot.label}</p>
-                      <p className="text-xs text-amber-700/90 dark:text-amber-200/80">Status: {slot.status}</p>
+                      <p className="text-sm font-semibold text-lundies-peat dark:text-neutral-200">{slot.label}</p>
+                      <p className="text-xs text-lundies-peat/90 dark:text-neutral-200/80">Status: {slot.status}</p>
                     </div>
                     <button
                       type="button"
                       onClick={() => onSelectAlternative(slot.id)}
-                      className="rounded-lg border border-emerald-500 px-3 py-1 text-xs font-semibold text-emerald-700 transition hover:bg-emerald-100 dark:border-emerald-400 dark:text-emerald-200 dark:hover:bg-emerald-900/30"
+                      className="rounded-lg border border-lundies-moss px-3 py-1 text-xs font-semibold text-lundies-moss transition hover:bg-lundies-heather/40 dark:border-lundies-moss/70 dark:text-neutral-200 dark:hover:bg-neutral-900/50"
                     >
                       Switch to this time
                     </button>


### PR DESCRIPTION
## Summary
- refresh global surface palette with neutral gradients that match the Schiehallion aesthetic
- restyle admin landing, dashboard, and staff login to use the warm lundies colourway and consistent neutral surfaces
- align restaurant guest and management interfaces plus the waitlist panel with the same earth-toned theme

## Testing
- npm run lint *(fails: repository has pre-existing lint errors outside the scope of these changes)*

------
https://chatgpt.com/codex/tasks/task_e_68d31e558cb883328ff7fb7f41dcb3df