### PR TITLE
feat: redesign landing experience

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -13,21 +13,33 @@
   --text-muted: 96 92 84;
 }
 
+html {
+  scroll-behavior: smooth;
+}
+
 body {
   min-height: 100vh;
   color: rgb(var(--text-primary));
   background-color: rgb(var(--surface-base));
-  background:
-    radial-gradient(circle at 18% 18%, rgba(var(--accent-green) / 0.18), transparent 55%),
-    radial-gradient(circle at 82% 8%, rgba(var(--accent-brown) / 0.12), transparent 45%),
-    linear-gradient(
-      to bottom,
-      rgb(var(--surface-base)),
-      rgb(var(--surface-muted)) 45%,
-      rgb(var(--surface-accent))
-    );
+  font-family: var(--font-sans), 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   font-feature-settings: 'cv02', 'cv03', 'cv04', 'cv11';
   -webkit-font-smoothing: antialiased;
+  letter-spacing: 0.01em;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: var(--font-display), 'Playfair Display', Georgia, serif;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+}
+
+section {
+  scroll-margin-top: 120px;
 }
 
 /* Image loading animations */
@@ -62,4 +74,65 @@ body {
 img {
   image-rendering: -webkit-optimize-contrast;
   image-rendering: optimize-contrast;
+}
+
+.reveal-element {
+  opacity: 0;
+  transform: translateY(48px);
+  transition: opacity 0.9s cubic-bezier(0.22, 1, 0.36, 1), transform 0.9s cubic-bezier(0.22, 1, 0.36, 1);
+  will-change: opacity, transform;
+}
+
+.reveal-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.scroll-indicator {
+  position: relative;
+  width: 2px;
+  height: 64px;
+  overflow: hidden;
+  background-color: rgba(var(--text-muted) / 0.2);
+}
+
+.scroll-indicator::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 40%;
+  background-color: rgb(var(--text-primary));
+  border-radius: 9999px;
+  animation: scrollPulse 2.4s ease-in-out infinite;
+}
+
+@keyframes scrollPulse {
+  0% {
+    transform: translateY(-100%);
+    opacity: 0;
+  }
+  30% {
+    opacity: 1;
+  }
+  100% {
+    transform: translateY(180%);
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  .reveal-element {
+    opacity: 1;
+    transform: none;
+    transition: none;
+  }
+
+  .scroll-indicator::after {
+    animation: none;
+  }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,10 +1,20 @@
 import type { Metadata } from 'next'
-import { Inter } from 'next/font/google'
+import { Cormorant_Garamond, Work_Sans } from 'next/font/google'
 import './globals.css'
 import { AuthProvider } from '@/context/AuthContext'
 import ChatbotWidget from '@/components/chat/ChatbotWidget'
 
-const inter = Inter({ subsets: ['latin'] })
+const display = Cormorant_Garamond({
+  subsets: ['latin'],
+  weight: ['400', '500', '600', '700'],
+  variable: '--font-display',
+})
+
+const sans = Work_Sans({
+  subsets: ['latin'],
+  weight: ['300', '400', '500', '600', '700'],
+  variable: '--font-sans',
+})
 
 export const metadata: Metadata = {
   title: 'Schiehallion Hotel · Highland Hospitality Reimagined',
@@ -19,7 +29,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body className={inter.className}>
+      <body className={`${sans.variable} ${display.variable}`}>
         <AuthProvider>
           {children}
           <ChatbotWidget />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,109 +1,112 @@
 'use client'
 
+import Image from 'next/image'
 import Link from 'next/link'
-import { useState, lazy, Suspense } from 'react'
-import { useAuth } from '@/context/AuthContext'
+import { lazy, Suspense, useEffect, useMemo, useState } from 'react'
+
 import LoginForm from '@/components/LoginForm'
 import SiteNavigation from '@/components/navigation/SiteNavigation'
-import NavUserProfile from '@/components/NavUserProfile'
+import { useAuth } from '@/context/AuthContext'
 
 const ConciergeChatWidget = lazy(() => import('@/components/concierge/ConciergeChatWidget'))
 
 const landingSections = [
-  { label: 'Rooms Overview', href: '/#rooms' },
-  { label: 'Dining Journey', href: '/#dining' },
-  { label: 'Experiences', href: '/#experiences' },
-  { label: 'Technology', href: '/#technology' },
-  { label: 'Operations', href: '/#operations' },
-  { label: 'Connect', href: '/#contact' },
+  { label: 'Story', href: '#story' },
+  { label: 'Rooms', href: '#rooms' },
+  { label: 'Dining', href: '#dining' },
+  { label: 'Experiences', href: '#experiences' },
+  { label: 'Technology', href: '#technology' },
+  { label: 'Operations', href: '#operations' },
+  { label: 'Awards', href: '#awards' },
+  { label: 'Contact', href: '#contact' },
 ]
 
-const heroStats = [
-  { label: 'Heritage rooms & suites', value: '15+' },
-  { label: 'Guest rating', value: '4.8/5' },
-  { label: 'Local partners', value: '12' },
+const heroImages = [
+  {
+    src: '/images/rooms/generated/suite/suite-artistic-1759248824246-ur9015.png',
+    alt: 'Soft morning light inside the Schiehallion loft suite',
+    caption: 'Loch Tay suites with tailored service',
+  },
+  {
+    src: '/images/rooms/generated/deluxe/deluxe-artistic-1759248801864-outd2c.png',
+    alt: 'Deluxe room featuring freestanding bath and herringbone floors',
+    caption: 'Deluxe comforts with Highland textures',
+  },
+  {
+    src: '/images/rooms/generated/family/family-artistic-1759248840189-b78zgy.png',
+    alt: 'Family suite with warm timber panelling and seating nook',
+    caption: 'Family suites crafted for together time',
+  },
 ]
 
-const roomShowcase = [
+const roomCollections = [
   {
     name: 'Highland View Double',
-    vibe: 'Cosy double • Loch-side outlook',
-    occupancy: '2 adults · 1 child',
-    packages: ['Bed & Breakfast', 'Dinner, Bed & Breakfast'],
-    features: ['Super-king bed', 'Walk-in rainfall shower', 'Loch Tay welcome hamper'],
-    notes:
-      'Perfect for Highland Explorers planning a two-night getaway with fresh pastries delivered each morning.',
+    summary: 'Loch-side calm, super-king sleep, fresh pastries on cue.',
+    image: '/images/rooms/generated/standard/standard-artistic-1759248767421-r0mln6.png',
+    meta: 'Signature Double · 2 adults + child',
   },
   {
     name: 'Riverside Twin Retreat',
-    vibe: 'Twin • Work-friendly comfort',
-    occupancy: '2 adults',
-    packages: ['Room Only', 'Corporate Express'],
-    features: ['Ergonomic workspace', 'Ultrafast WiFi', 'Same-day laundry options'],
-    notes:
-      'Built for Business Travellers who need a calm base before meetings in Perthshire and beyond.',
+    summary: 'Twin comfort with ergonomic workspace and ultrafast Wi-Fi.',
+    image: '/images/rooms/generated/accessible/accessible-artistic-1759248857443-57441r.png',
+    meta: 'Twin · Work-ready sanctuary',
   },
   {
     name: 'Family Cairngorm Suite',
-    vibe: 'Family • Interconnected',
-    occupancy: '2 adults · 2 children',
-    packages: ['Family Adventure', 'Breakfast & Supper Club'],
-    features: ['Separate kids nook', 'Games chest', 'Complimentary Beyond Adventure vouchers'],
-    notes:
-      'Give Event Planners a flexible hub for multi-room bookings and coordinated dining times.',
+    summary: 'Interconnected rooms, games chest, and concierge planning.',
+    image: '/images/rooms/generated/family/family-artistic-1759248840189-b78zgy.png',
+    meta: 'Two-bedroom suite · 2 adults · 2 children',
   },
   {
     name: 'Deluxe Schiehallion Loft',
-    vibe: 'Suite • Romantic finish',
-    occupancy: '2 adults',
-    packages: ['Celebration Stay', 'Seasonal Tasting Journey'],
-    features: ['In-room telescope', 'Freestanding bath', 'Private concierge check-in'],
-    notes:
-      'Our hero room for storytelling — perfect for campaign landing pages and influencer partnerships.',
+    summary: 'Freestanding bath, private check-in, telescope over Ben Lawers.',
+    image: '/images/rooms/generated/deluxe/deluxe-artistic-1759248801864-outd2c.png',
+    meta: 'Loft suite · Celebrations',
   },
 ]
 
 const diningMoments = [
   {
     title: 'The Schiehallion Kitchen',
-    description:
-      'Local produce takes centre stage — think Perthshire lamb, foraged chanterelles, and artisan bakers from Aberfeldy.',
-    highlights: ['Seasonal tasting menus', 'Vegetarian & vegan pairings', 'Sommelier wine flights'],
+    description: 'Seasonal tasting journeys with Perthshire produce and sommelier pairings.',
+    image: '/images/rooms/generated/suite/suite-artistic-1759248824246-ur9015.png',
+    highlights: ['Four-course tasting', 'Vegan pairings', 'Wine flights'],
   },
   {
     title: 'Breakfast & Brunch',
-    description:
-      'Sunrise spreads with hearty Scottish classics, continental favourites, and mindful options for early adventures.',
-    highlights: ['Freshly baked morning rolls', 'Locally roasted Glen Lyon coffee', 'Express takeaway for river guides'],
+    description: 'Sunrise spreads, Glen Lyon coffee, and take-away baskets for river guides.',
+    image: '/images/rooms/generated/standard/standard-artistic-1759248767421-r0mln6.png',
+    highlights: ['Fresh pastries', 'Express takeaway', 'Locally roasted beans'],
   },
   {
-    title: 'Afternoon Tea & Sunday Roast',
-    description:
-      'Weekend rituals return with sweet treats, Highland shortbread towers, and a countdown to our famous roast service.',
-    highlights: ['Live roast countdown timer', 'Allergen-aware patisserie', 'Kids discovery tasting plates'],
+    title: 'Afternoon Rituals',
+    description: 'Highland shortbread towers, live roast countdown, patisserie made in-house.',
+    image: '/images/rooms/generated/accessible/accessible-artistic-1759248857443-57441r.png',
+    highlights: ['Seasonal tea menu', 'Allergen aware', 'Sunday roast theatre'],
   },
 ]
 
-const experienceHighlights = [
+const experienceStories = [
   {
     name: 'Dewars Aberfeldy Distillery',
     distance: '2 miles',
-    focus: 'Cask tasting tours, heritage storyrooms, curated whisky flights.',
+    description: 'Heritage tastings, storytelling lounges, bespoke whisky flights.',
   },
   {
     name: 'Beyond Adventure',
     distance: 'On the River Tay',
-    focus: 'Kayaking, paddleboarding, and bespoke river guides for families.',
+    description: 'Kayaking, paddleboarding, and private guides for every level.',
   },
   {
     name: 'Loch Tay & Ben Lawers',
     distance: '15 minutes',
-    focus: 'Mountain trails, sunrise hikes, and photographer-led expeditions.',
+    description: 'Sunrise hikes, photographer-led expeditions, snowline picnics.',
   },
   {
     name: 'Aberfeldy Watermill & Gallery',
-    distance: '5 minutes walk',
-    focus: 'Independent bookshop, art exhibitions, and slow-travel inspiration.',
+    distance: '5 minute walk',
+    description: 'Independent bookshop, art exhibitions, slow-travel inspiration.',
   },
 ]
 
@@ -111,294 +114,271 @@ const technologyPillars = [
   {
     title: 'Unified Booking Surface',
     detail:
-      'Next.js 15 experience layer that powers web, PWA, and admin journeys with shared design tokens and accessibility baked in.',
+      'Next.js 15 powering responsive web, PWA, and admin journeys with shared tokens and inclusive patterns.',
   },
   {
     title: 'Real-time Availability Core',
-    detail:
-      'Firestore and Realtime Database keep room calendars, restaurant tables, and waitlists instantly synced across channels.',
+    detail: 'Firestore + Realtime Database syncing room calendars, dining tables, and partner allotments.',
   },
   {
     title: 'Edge-first Performance',
-    detail:
-      'Vercel Edge network, caching strategies, and CDN image optimisation keep global guests under 100ms to first content.',
+    detail: 'CDN image optimisation, caching strategies, and sub-100ms first content worldwide.',
   },
   {
-    title: 'Payments & Compliance',
-    detail:
-      'Stripe for secure checkouts, PCI-ready workflows, and automated confirmations via SendGrid and Twilio.',
-  },
-]
-
-const conciergeFeatures = [
-  {
-    title: 'Virtual Highland Host',
-    description:
-      'AI concierge that curates itineraries, translates Gaelic greetings, and matches accessibility needs to the right rooms.',
-  },
-  {
-    title: 'Weather-smart Planning',
-    description:
-      'Connects to live forecasts to shift guests from loch cruises to distillery tours when the clouds roll in.',
-  },
-  {
-    title: 'Culinary Guide',
-    description:
-      'Handles menu queries, allergen checks, and wine pairings with chef-approved responses in seconds.',
-  },
-  {
-    title: 'Partner Integrations',
-    description:
-      'Books distillery tours, adventure sessions, and tee times via channel-ready APIs.',
-  },
-  {
-    title: 'Upsell Intelligence',
-    description:
-      'Suggests upgrades, late check-outs, and local experiences based on guest segments and booking history.',
-  },
-]
-
-const bookingFlow = [
-  {
-    stage: '1. Discover & Dream',
-    description:
-      'Story-first landing pages with hero video, rich imagery, and SEO content for every persona.',
-    touchpoints: ['Dynamic hero modules', 'Local attraction hub', 'Personalised recommendations'],
-  },
-  {
-    stage: '2. Build the Stay',
-    description:
-      'Drag-and-drop room selection, package toggles, and multi-room cart with live availability.',
-    touchpoints: ['Realtime room grid', 'Package comparison', 'Guest preference capture'],
-  },
-  {
-    stage: '3. Dine & Explore',
-    description:
-      'Table reservations, waitlist management, and experience add-ons all in one journey.',
-    touchpoints: ['Interactive floor plan', 'Experience marketplace', 'Automated partner booking'],
-  },
-  {
-    stage: '4. Confirm & Delight',
-    description:
-      'Stripe payments, instant confirmation, and automated concierge handover for pre-arrival nurture.',
-    touchpoints: ['Payment intents', 'Email & SMS triggers', 'AI concierge welcome'],
+    title: 'Payments & Assurance',
+    detail: 'Stripe integrations with 3D Secure, automated confirmations, and audit-ready histories.',
   },
 ]
 
 const operationsHighlights = [
   {
     title: 'Operations Command Centre',
-    bullets: ['Drag-and-drop room assignment board', 'Housekeeping and maintenance snapshots', 'Overbooking guardrails and alerts'],
+    points: ['Drag-and-drop room assignment', 'Housekeeping snapshots', 'Proactive maintenance alerts'],
   },
   {
     title: 'Revenue Studio',
-    bullets: ['Dynamic pricing experiments', 'Package performance analytics', 'Competitor rate monitoring dashboards'],
+    points: ['Dynamic pricing experiments', 'Package performance analytics', 'Competitive benchmarks'],
   },
   {
     title: 'Guest Relationship Desk',
-    bullets: ['Pre-arrival and post-stay automation', 'Loyalty segmentation', 'Unified messaging inbox'],
+    points: ['Unified inbox', 'Pre-arrival and post-stay flows', 'Loyalty segmentation'],
   },
 ]
 
-const integrationPartners = [
-  { name: 'Hotels.uk.com Channel Manager', focus: 'Rate parity & inventory sync', priority: 'Critical', status: 'API discovery complete' },
-  { name: 'Booking.com XML', focus: 'Two-way availability updates', priority: 'Critical', status: 'Schema mapping underway' },
-  { name: 'Stripe Payments', focus: '3D Secure & multi-currency', priority: 'Critical', status: 'Sandbox connected' },
-  { name: 'SendGrid & Twilio', focus: 'Transactional messaging', priority: 'High', status: 'Template design in progress' },
-  { name: 'VisitScotland & Weather APIs', focus: 'Live events & climate signals', priority: 'Medium', status: 'Data contract drafting' },
-  { name: 'Google Business Reviews', focus: 'Reputation insights', priority: 'Medium', status: 'Aggregation backlog' },
+const awards = [
+  { label: 'Scottish Hotel Awards', detail: 'Boutique Hotel of the Year · 2023' },
+  { label: 'Green Key Certification', detail: 'Sustainable operations accreditation' },
+  { label: 'VisitScotland', detail: '5-Star Gold Guest Accommodation' },
+  { label: 'Condé Nast Traveller', detail: 'Readers Choice Top 20 Highlands' },
 ]
 
-const milestones = [
-  {
-    phase: 'Phase 0 · Experience Blueprint (Now)',
-    detail: 'Stakeholder alignment, content audit, data architecture, and this visual-first articulation of the future state.',
-  },
-  {
-    phase: 'Phase 1 · Booking Foundation',
-    detail: 'Deliver room catalogue, availability services, and baseline payments with progressive enhancement.',
-  },
-  {
-    phase: 'Phase 2 · AI Concierge & Dining',
-    detail: 'Layer in restaurant floor management, AI concierge flows, and partner integrations.',
-  },
-  {
-    phase: 'Phase 3 · Operations Intelligence',
-    detail: 'Launch admin dashboards, forecasting engines, and loyalty programming tied to live data.',
-  },
+const contactChannels = [
+  { label: 'Visit', detail: '1-5 Dunkeld Street, Aberfeldy, PH15 2AA', href: 'https://maps.app.goo.gl/qxgTB1gYkn12' },
+  { label: 'Reserve', detail: '+44 (0)1887 352 214', href: 'tel:+441887352214' },
+  { label: 'Enquire', detail: 'hello@schiehallionhotel.co.uk', href: 'mailto:hello@schiehallionhotel.co.uk' },
 ]
 
-function SectionHeader({
-  eyebrow,
-  title,
-  description,
-  align = 'center',
-}: {
-  eyebrow: string
-  title: string
-  description?: string
-  align?: 'left' | 'center'
-}) {
-  const alignmentClasses = align === 'center' ? 'mx-auto text-center' : ''
+function usePrefersReducedMotion() {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false)
 
-  return (
-    <div className={`max-w-3xl ${alignmentClasses}`}>
-      <p className="text-xs font-semibold uppercase tracking-[0.3em] text-lundies-moss">{eyebrow}</p>
-      <h2 className="mt-4 text-3xl font-semibold leading-tight text-lundies-charcoal sm:text-4xl">{title}</h2>
-      {description ? <p className="mt-4 text-base text-lundies-peat sm:text-lg">{description}</p> : null}
-    </div>
-  )
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)')
+    const handleChange = () => setPrefersReducedMotion(mediaQuery.matches)
+
+    handleChange()
+    mediaQuery.addEventListener('change', handleChange)
+
+    return () => mediaQuery.removeEventListener('change', handleChange)
+  }, [])
+
+  return prefersReducedMotion
 }
 
 export default function Home() {
-  const { user, userProfile } = useAuth()
-  const [showGuestRegistration, setShowGuestRegistration] = useState(false)
+  const { user } = useAuth()
+  const prefersReducedMotion = usePrefersReducedMotion()
+  const [activeHero, setActiveHero] = useState(0)
+  const [showLogin, setShowLogin] = useState(false)
 
-  if (!user) {
-    return (
-      <main className="flex min-h-screen items-center justify-center bg-gradient-to-br from-lundies-ivory via-lundies-linen to-lundies-stone p-4">
-        <div className="w-full max-w-md">
-          <div className="mb-8 text-center">
-            <h1 className="mb-2 text-3xl font-bold text-lundies-charcoal">Schiehallion Hotel</h1>
-            <p className="text-lundies-peat">Highland hospitality reimagined</p>
-          </div>
-          <LoginForm />
-        </div>
-      </main>
+  useEffect(() => {
+    if (prefersReducedMotion) return
+
+    const timer = window.setInterval(() => {
+      setActiveHero((current) => (current + 1) % heroImages.length)
+    }, 7000)
+
+    return () => window.clearInterval(timer)
+  }, [prefersReducedMotion])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+
+    const revealElements = document.querySelectorAll<HTMLElement>('[data-reveal]')
+
+    if (!revealElements.length) return
+
+    if (prefersReducedMotion) {
+      revealElements.forEach((element) => {
+        element.classList.add('reveal-visible')
+      })
+      return
+    }
+
+    revealElements.forEach((element) => {
+      element.classList.add('reveal-element')
+    })
+
+    const observer = new IntersectionObserver(
+      (entries, obs) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('reveal-visible')
+            obs.unobserve(entry.target)
+          }
+        })
+      },
+      { threshold: 0.15, rootMargin: '0px 0px -10% 0px' },
     )
-  }
+
+    revealElements.forEach((element) => observer.observe(element))
+
+    return () => observer.disconnect()
+  }, [prefersReducedMotion])
+
+  const heroCaptions = useMemo(() => heroImages.map((image) => image.caption), [])
+
+  useEffect(() => {
+    if (!showLogin) return
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setShowLogin(false)
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [showLogin])
+
+  useEffect(() => {
+    if (user) {
+      setShowLogin(false)
+    }
+  }, [user])
 
   return (
-    <main className="relative overflow-hidden bg-lundies-ivory text-lundies-charcoal">
-      <div className="pointer-events-none absolute inset-0 -z-10">
-        <div className="absolute left-1/2 top-[-10%] h-[32rem] w-[32rem] -translate-x-1/2 rounded-full bg-lundies-heather/30 blur-[160px]" />
-        <div className="absolute right-[-10%] top-1/3 h-[24rem] w-[24rem] rounded-full bg-lundies-sand/40 blur-[180px]" />
-        <div className="absolute bottom-[-20%] left-[5%] h-[28rem] w-[28rem] rounded-full bg-lundies-peat/20 blur-[160px]" />
-      </div>
+    <main className="relative bg-lundies-ivory text-lundies-charcoal">
+      <SiteNavigation
+        sectionLinks={landingSections}
+        isSticky
+        layout="landing"
+        actionSlot={
+          user ? (
+            <Link
+              href="/booking"
+              className="inline-flex rounded-full border border-lundies-stone/70 px-4 py-2 text-[10px] font-semibold uppercase tracking-[0.35em] text-lundies-charcoal transition hover:bg-white/70"
+            >
+              Manage booking
+            </Link>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setShowLogin(true)}
+              className="inline-flex rounded-full border border-lundies-stone/70 px-4 py-2 text-[10px] font-semibold uppercase tracking-[0.35em] text-lundies-charcoal transition hover:bg-white/70"
+            >
+              Sign in
+            </button>
+          )
+        }
+      />
 
-      <header className="relative">
-        <div className="mx-auto flex max-w-6xl flex-col gap-12 px-6 pb-20 pt-12 sm:pt-16">
-          <SiteNavigation
-            sectionLinks={landingSections}
-            actionSlot={
+      <section
+        id="story"
+        className="relative flex min-h-[90vh] flex-col justify-end overflow-hidden border-b border-lundies-stone/40 bg-black/60"
+      >
+        <div className="absolute inset-0">
+          {heroImages.map((image, index) => (
+            <Image
+              key={image.src}
+              src={image.src}
+              alt={image.alt}
+              fill
+              priority={index === 0}
+              sizes="100vw"
+              className={`object-cover transition-opacity duration-[1200ms] ease-out ${
+                index === activeHero ? 'opacity-100' : 'opacity-0'
+              }`}
+            />
+          ))}
+          <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/20 to-black/60" />
+        </div>
+
+        <div className="relative mx-auto flex w-full max-w-6xl flex-col gap-10 px-6 pb-24 pt-32 text-white">
+          <div className="max-w-3xl space-y-6" data-reveal>
+            <p className="text-xs font-semibold uppercase tracking-[0.45em] text-white/70">Aberfeldy, Scotland</p>
+            <h1 className="text-4xl leading-tight sm:text-5xl lg:text-6xl">
+              A minimalist canvas for luxury Highland hospitality
+            </h1>
+            <p className="max-w-xl text-base text-white/80 sm:text-lg">
+              We distilled the Schiehallion experience into a single flowing page: cinematic imagery, crafted typography, and a
+              calm rhythm from arrival to farewell.
+            </p>
+            <div className="flex flex-wrap gap-3">
               <Link
-                href="/rooms"
-                className="rounded-full border border-lundies-stone/70 bg-white/60 px-3 py-1.5 text-xs font-medium uppercase tracking-[0.2em] text-lundies-moss transition hover:bg-white/80 hover:text-lundies-charcoal"
+                href="/booking"
+                className="rounded-full bg-white px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-lundies-charcoal transition hover:bg-white/90"
               >
-                Browse Rooms
+                Book your stay
               </Link>
-            }
-          />
-
-          <div className="grid gap-12 lg:grid-cols-[1.1fr_0.9fr] lg:items-center">
-            <div className="space-y-8">
-              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-lundies-moss">Highland hospitality reimagined</p>
-              <h1 className="text-4xl font-semibold leading-tight text-lundies-charcoal sm:text-5xl lg:text-6xl">
-                A modern booking journey for Aberfeldy’s landmark hotel
-              </h1>
-              <p className="max-w-xl text-base text-lundies-peat sm:text-lg">
-                This first-pass interface stitches together rooms, dining, experiences, and intelligent guest services into one
-                cohesive digital platform. Every section below maps directly to the architecture, data models, and product
-                ambitions outlined in the Schiehallion documentation.
-              </p>
-              <div className="flex flex-wrap gap-4">
-                <a
-                  href="/booking"
-                  className="rounded-full bg-lundies-heather px-6 py-3 text-sm font-semibold uppercase tracking-[0.2em] text-lundies-charcoal transition hover:bg-lundies-heather/80"
-                >
-                  Book Now
-                </a>
-                <a
-                  href="/rooms"
-                  className="rounded-full border border-lundies-moss px-6 py-3 text-sm font-semibold uppercase tracking-[0.2em] text-lundies-moss transition hover:bg-lundies-moss/10"
-                >
-                  Browse Rooms
-                </a>
-                <a
-                  href="#rooms"
-                  className="rounded-full border border-lundies-stone/70 px-6 py-3 text-sm font-semibold uppercase tracking-[0.2em] text-lundies-charcoal transition hover:bg-white/70"
-                >
-                  Room Overview
-                </a>
-                <a
-                  href="#technology"
-                  className="rounded-full border border-lundies-stone/70 px-6 py-3 text-sm font-semibold uppercase tracking-[0.2em] text-lundies-charcoal transition hover:bg-white/70"
-                >
-                  View Platform Plan
-                </a>
-              </div>
+              <Link
+                href="#rooms"
+                className="rounded-full border border-white/40 px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-white transition hover:border-white hover:bg-white/10"
+              >
+                Explore rooms
+              </Link>
             </div>
-            <div className="grid gap-6 rounded-3xl border border-lundies-stone/60 bg-white/80 p-8 shadow-xl backdrop-blur">
-              <div className="space-y-4">
-                <h2 className="text-xl font-semibold text-lundies-charcoal">Why this matters</h2>
-                <p className="text-sm text-lundies-peat">
-                  Designed for mobile-first bookings, high repeat guests, and story-driven marketing campaigns. This canvas sets the
-                  tone for visual design, content hierarchy, and future interactive prototypes.
-                </p>
-              </div>
-              <dl className="grid gap-4 sm:grid-cols-3">
-                {heroStats.map((stat) => (
-                  <div key={stat.label} className="rounded-2xl bg-lundies-stone/50 p-4 text-center shadow-inner">
-                    <dt className="text-xs uppercase tracking-[0.3em] text-lundies-moss">{stat.label}</dt>
-                    <dd className="mt-2 text-2xl font-semibold text-lundies-charcoal">{stat.value}</dd>
-                  </div>
-                ))}
-              </dl>
-              <div className="rounded-2xl bg-lundies-heather/20 p-4 text-sm text-lundies-charcoal">
-                Future Enhancements: integrate live availability widgets, hero photography, and real guest storytelling once data connections are in place.
-              </div>
+          </div>
+
+          <div className="flex items-end justify-between" data-reveal>
+            <div>
+              <p className="text-sm uppercase tracking-[0.35em] text-white/70">Now featuring</p>
+              <p className="mt-3 text-lg font-light text-white">
+                {heroCaptions[activeHero]}
+              </p>
+            </div>
+            <div className="hidden items-center gap-4 sm:flex">
+              <span className="text-xs uppercase tracking-[0.3em] text-white/50">Scroll</span>
+              <div className="scroll-indicator" aria-hidden="true" />
             </div>
           </div>
         </div>
-      </header>
+      </section>
 
-      <section id="rooms" className="relative border-t border-lundies-stone/60 bg-white/70 py-20 backdrop-blur-sm">
-        <div className="mx-auto max-w-6xl px-6">
-          <SectionHeader
-            eyebrow="Rooms & Suites"
-            title="Curated stays for every Schiehallion persona"
-            description="Each card mirrors a Firestore room document with packages, amenities, and storytelling hooks ready for CMS integration."
-            align="left"
-          />
-          <div className="mt-12 grid gap-6 md:grid-cols-2">
-            {roomShowcase.map((room) => (
+      <section id="rooms" className="bg-lundies-ivory py-24">
+        <div className="mx-auto flex w-full max-w-6xl flex-col gap-12 px-6">
+          <header className="max-w-2xl space-y-4" data-reveal>
+            <p className="text-xs font-semibold uppercase tracking-[0.4em] text-lundies-moss">Rooms & suites</p>
+            <h2 className="text-3xl sm:text-4xl">Tailored stays for every travel story</h2>
+            <p className="text-base text-lundies-peat">
+              Each room is staged for photography, future availability widgets, and campaign-ready storytelling.
+            </p>
+          </header>
+
+          <div className="space-y-16">
+            {roomCollections.map((room, index) => (
               <article
                 key={room.name}
-                className="flex flex-col gap-5 rounded-3xl border border-lundies-stone/60 bg-white/90 p-6 shadow-lg shadow-lundies-stone/40"
+                className={`grid gap-10 md:grid-cols-2 md:items-center ${index % 2 === 1 ? 'md:grid-flow-col-dense' : ''}`}
               >
-                <div>
-                  <h3 className="text-2xl font-semibold text-lundies-charcoal">{room.name}</h3>
-                  <p className="text-sm uppercase tracking-[0.25em] text-lundies-moss">{room.vibe}</p>
+                <div className="relative aspect-[4/3] overflow-hidden rounded-[2.5rem] bg-lundies-stone/40" data-reveal>
+                  <Image
+                    src={room.image}
+                    alt={room.name}
+                    fill
+                    sizes="(min-width: 768px) 50vw, 100vw"
+                    className="object-cover"
+                    loading={index === 0 ? 'eager' : 'lazy'}
+                  />
                 </div>
-                <p className="text-sm text-lundies-peat">{room.notes}</p>
-                <div className="grid gap-4 text-sm text-lundies-charcoal">
-                  <p className="flex items-center justify-between rounded-2xl bg-lundies-stone/40 px-4 py-3 text-lundies-charcoal">
-                    <span className="font-medium text-lundies-moss">Occupancy</span>
-                    <span>{room.occupancy}</span>
-                  </p>
-                  <div className="rounded-2xl bg-lundies-linen p-4">
-                    <p className="text-xs uppercase tracking-[0.25em] text-lundies-moss">Packages</p>
-                    <ul className="mt-3 space-y-2 text-sm">
-                      {room.packages.map((pkg) => (
-                        <li
-                          key={pkg}
-                          className="flex items-center justify-between gap-2 rounded-full border border-lundies-stone/60 bg-white/80 px-3 py-2"
-                        >
-                          <span>{pkg}</span>
-                          <span className="text-lundies-moss">Live pricing soon</span>
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                  <div className="rounded-2xl bg-lundies-linen p-4">
-                    <p className="text-xs uppercase tracking-[0.25em] text-lundies-moss">Signature touches</p>
-                    <ul className="mt-3 grid gap-2 text-sm">
-                      {room.features.map((feature) => (
-                        <li key={feature} className="rounded-full bg-white/80 px-3 py-2 text-lundies-peat">
-                          {feature}
-                        </li>
-                      ))}
-                    </ul>
+                <div className="space-y-6" data-reveal>
+                  <p className="text-xs uppercase tracking-[0.4em] text-lundies-moss">{room.meta}</p>
+                  <h3 className="text-3xl">{room.name}</h3>
+                  <p className="text-base text-lundies-peat">{room.summary}</p>
+                  <div className="flex flex-wrap gap-3">
+                    <Link
+                      href="/rooms"
+                      className="rounded-full border border-lundies-stone px-5 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-lundies-charcoal transition hover:bg-white"
+                    >
+                      Room details
+                    </Link>
+                    <Link
+                      href="/booking"
+                      className="rounded-full bg-lundies-heather px-5 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-lundies-charcoal transition hover:bg-lundies-heather/80"
+                    >
+                      Check availability
+                    </Link>
                   </div>
                 </div>
               </article>
@@ -407,168 +387,122 @@ export default function Home() {
         </div>
       </section>
 
-      <section
-        id="dining"
-        className="relative border-t border-lundies-stone/60 bg-gradient-to-b from-white/90 to-lundies-linen/80 py-20"
-      >
-        <div className="mx-auto max-w-6xl px-6">
-          <SectionHeader
-            eyebrow="Dining"
-            title="Celebrating Perthshire produce from morning to late night"
-            description="Structured for CMS-powered menu updates, live table availability, and storytelling content modules."
-            align="left"
-          />
-          <div className="mt-12 grid gap-6 md:grid-cols-3">
+      <section id="dining" className="bg-white py-24">
+        <div className="mx-auto w-full max-w-6xl px-6">
+          <header className="max-w-2xl space-y-4" data-reveal>
+            <p className="text-xs font-semibold uppercase tracking-[0.4em] text-lundies-moss">Dining journey</p>
+            <h2 className="text-3xl sm:text-4xl">Culinary moments paced through the day</h2>
+            <p className="text-base text-lundies-peat">
+              Menus that celebrate Perthshire produce with immersive photography ready for story-led campaigns.
+            </p>
+          </header>
+
+          <div className="mt-16 grid gap-12 md:grid-cols-3">
             {diningMoments.map((moment) => (
-              <article
-                key={moment.title}
-                className="flex flex-col gap-4 rounded-3xl border border-lundies-stone/60 bg-white/90 p-6 shadow-sm shadow-lundies-stone/30"
-              >
-                <h3 className="text-xl font-semibold text-lundies-charcoal">{moment.title}</h3>
-                <p className="text-sm text-lundies-peat">{moment.description}</p>
-                <ul className="mt-auto space-y-2 text-sm text-lundies-charcoal">
-                  {moment.highlights.map((item) => (
-                    <li key={item} className="rounded-full bg-lundies-heather/30 px-3 py-2">{item}</li>
-                  ))}
-                </ul>
+              <article key={moment.title} className="space-y-6" data-reveal>
+                <div className="relative aspect-[3/4] overflow-hidden rounded-[2rem] bg-lundies-stone/30">
+                  <Image
+                    src={moment.image}
+                    alt={moment.title}
+                    fill
+                    sizes="(min-width: 768px) 33vw, 100vw"
+                    className="object-cover"
+                    loading="lazy"
+                  />
+                </div>
+                <div className="space-y-3">
+                  <h3 className="text-2xl">{moment.title}</h3>
+                  <p className="text-sm text-lundies-peat">{moment.description}</p>
+                  <ul className="space-y-2 text-xs uppercase tracking-[0.3em] text-lundies-moss">
+                    {moment.highlights.map((highlight) => (
+                      <li key={highlight} className="flex items-center justify-between border-b border-lundies-stone/50 pb-2">
+                        <span>{highlight}</span>
+                        <span className="text-lundies-charcoal/50">Soon in app</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
               </article>
             ))}
-          </div>
-          <div className="mt-10 grid gap-6 rounded-3xl border border-lundies-heather/40 bg-lundies-heather/20 p-6 text-sm text-lundies-charcoal md:grid-cols-3">
-            <div>
-              <p className="text-xs uppercase tracking-[0.25em] text-lundies-moss">Restaurant Operations</p>
-              <p className="mt-2 text-lundies-charcoal">
-                Interactive floor plan, waitlist management, and POS integrations will sit beneath this hospitality storytelling.
-              </p>
-            </div>
-            <div>
-              <p className="text-xs uppercase tracking-[0.25em] text-lundies-moss">Guest Signals</p>
-              <p className="mt-2">
-                Capture dietary notes, celebration flags, and concierge tasks for the team dashboard.
-              </p>
-            </div>
-            <div>
-              <p className="text-xs uppercase tracking-[0.25em] text-lundies-moss">Content Rhythm</p>
-              <p className="mt-2">
-                Schedule Sunday roast countdowns, chef’s journal entries, and seasonal photography drops.
-              </p>
-            </div>
           </div>
         </div>
       </section>
 
-      <section id="experiences" className="relative border-t border-lundies-stone/60 bg-white/70 py-20 backdrop-blur-sm">
-        <div className="mx-auto max-w-6xl px-6">
-          <SectionHeader
-            eyebrow="Experiences"
-            title="Build itineraries that stretch beyond the hotel walls"
-            description="Data-ready attraction cards link to partner APIs, distance calculations, and AI-generated recommendations."
-            align="left"
-          />
-          <div className="mt-12 grid gap-6 md:grid-cols-2">
-            {experienceHighlights.map((experience) => (
-              <article
+      <section id="experiences" className="bg-lundies-ivory py-24">
+        <div className="mx-auto w-full max-w-6xl space-y-12 px-6">
+          <header className="max-w-2xl space-y-4" data-reveal>
+            <p className="text-xs font-semibold uppercase tracking-[0.4em] text-lundies-moss">Experiences</p>
+            <h2 className="text-3xl sm:text-4xl">Curated adventures around Aberfeldy</h2>
+            <p className="text-base text-lundies-peat">
+              Designed as swipeable stories with partner integrations and live availability hooks.
+            </p>
+          </header>
+
+          <div
+            className="flex gap-8 overflow-x-auto pb-4"
+            data-reveal
+            role="list"
+            aria-label="Experience highlights"
+          >
+            {experienceStories.map((experience) => (
+              <div
                 key={experience.name}
-                className="rounded-3xl border border-lundies-stone/60 bg-white/90 p-6 shadow-sm shadow-lundies-stone/40"
+                role="listitem"
+                className="min-w-[260px] max-w-xs flex-1 space-y-4 rounded-[2rem] border border-lundies-stone/60 bg-white/70 p-6 backdrop-blur"
               >
-                <div className="flex items-baseline justify-between gap-4">
-                  <h3 className="text-xl font-semibold text-lundies-charcoal">{experience.name}</h3>
-                  <span className="text-xs uppercase tracking-[0.25em] text-lundies-moss">{experience.distance}</span>
-                </div>
-                <p className="mt-4 text-sm text-lundies-peat">{experience.focus}</p>
-                <div className="mt-6 flex items-center justify-between text-xs uppercase tracking-[0.3em] text-lundies-moss">
-                  <span>Live data feed ready</span>
-                  <span>Partner onboarding</span>
-                </div>
-              </article>
+                <p className="text-xs uppercase tracking-[0.3em] text-lundies-moss">{experience.distance}</p>
+                <h3 className="text-2xl">{experience.name}</h3>
+                <p className="text-sm text-lundies-peat">{experience.description}</p>
+                <span className="text-xs uppercase tracking-[0.3em] text-lundies-charcoal/60">Concierge ready</span>
+              </div>
             ))}
           </div>
         </div>
       </section>
 
-      <section
-        id="technology"
-        className="relative border-t border-lundies-stone/60 bg-gradient-to-b from-lundies-linen/90 to-lundies-stone/70 py-20"
-      >
-        <div className="mx-auto max-w-6xl px-6">
-          <SectionHeader
-            eyebrow="Platform Architecture"
-            title="Nano Banana foundations tuned for hospitality"
-            description="Grounded in the architecture blueprint: client experiences on Next.js, real-time data via Firebase, and integrations powering conversions."
-          />
-          <div className="mt-12 grid gap-6 md:grid-cols-2">
+      <section id="technology" className="bg-white py-24">
+        <div className="mx-auto w-full max-w-6xl px-6">
+          <header className="max-w-2xl space-y-4" data-reveal>
+            <p className="text-xs font-semibold uppercase tracking-[0.4em] text-lundies-moss">Technology</p>
+            <h2 className="text-3xl sm:text-4xl">The platform behind the poise</h2>
+            <p className="text-base text-lundies-peat">
+              Modular services keep the guest journey quick, personalised, and future-friendly.
+            </p>
+          </header>
+
+          <div className="mt-16 grid gap-8 md:grid-cols-2" data-reveal>
             {technologyPillars.map((pillar) => (
               <article
                 key={pillar.title}
-                className="rounded-3xl border border-lundies-stone/60 bg-white/90 p-6 shadow-sm shadow-lundies-stone/40"
+                className="space-y-4 rounded-[2rem] border border-lundies-stone/60 bg-lundies-linen/80 p-8 shadow-sm"
               >
-                <h3 className="text-lg font-semibold text-lundies-charcoal">{pillar.title}</h3>
-                <p className="mt-4 text-sm text-lundies-peat">{pillar.detail}</p>
-              </article>
-            ))}
-          </div>
-          <div className="mt-12 grid gap-6 rounded-3xl border border-lundies-stone/70 bg-lundies-stone/30 p-6 md:grid-cols-4">
-            {bookingFlow.map((step) => (
-              <article
-                key={step.stage}
-                className="flex flex-col gap-4 rounded-2xl border border-lundies-stone/60 bg-white/90 p-4 text-lundies-charcoal"
-              >
-                <h4 className="text-base font-semibold text-lundies-charcoal">{step.stage}</h4>
-                <p className="text-sm text-lundies-peat">{step.description}</p>
-                <ul className="mt-auto space-y-1 text-xs text-lundies-charcoal">
-                  {step.touchpoints.map((touchpoint) => (
-                    <li key={touchpoint} className="rounded-full bg-lundies-heather/30 px-3 py-2">{touchpoint}</li>
-                  ))}
-                </ul>
+                <h3 className="text-2xl">{pillar.title}</h3>
+                <p className="text-sm text-lundies-peat">{pillar.detail}</p>
               </article>
             ))}
           </div>
         </div>
       </section>
 
-      <section id="concierge" className="relative border-t border-lundies-stone/60 bg-white/70 py-20 backdrop-blur-sm">
-        <div className="mx-auto max-w-6xl px-6">
-          <SectionHeader
-            eyebrow="AI Concierge"
-            title="Human warmth, AI speed"
-            description="Gemini and OpenAI services power contextual recommendations, multi-language support, and upsell journeys."
-            align="left"
-          />
-          <div className="mt-12 grid gap-6 md:grid-cols-2">
-            {conciergeFeatures.map((feature) => (
-              <article
-                key={feature.title}
-                className="rounded-3xl border border-lundies-heather/40 bg-lundies-heather/20 p-6 text-lundies-charcoal"
-              >
-                <h3 className="text-lg font-semibold text-lundies-charcoal">{feature.title}</h3>
-                <p className="mt-3 text-sm text-lundies-peat">{feature.description}</p>
-              </article>
-            ))}
-          </div>
-        </div>
-      </section>
+      <section id="operations" className="bg-lundies-ivory py-24">
+        <div className="mx-auto w-full max-w-6xl px-6">
+          <header className="max-w-2xl space-y-4" data-reveal>
+            <p className="text-xs font-semibold uppercase tracking-[0.4em] text-lundies-moss">Operations</p>
+            <h2 className="text-3xl sm:text-4xl">Empowering teams behind the scenes</h2>
+            <p className="text-base text-lundies-peat">
+              Interfaces choreographed for operations, revenue, and guest relations to collaborate in real time.
+            </p>
+          </header>
 
-      <section
-        id="operations"
-        className="relative border-t border-lundies-stone/60 bg-gradient-to-b from-lundies-linen/80 to-lundies-stone/60 py-20"
-      >
-        <div className="mx-auto max-w-6xl px-6">
-          <SectionHeader
-            eyebrow="Operations"
-            title="A command centre for the Schiehallion team"
-            description="Admin dashboards align with the architecture plan: Cloud Functions orchestrate automations, Redis accelerates forecasting, and Firestore stores operational states."
-          />
-          <div className="mt-12 grid gap-6 md:grid-cols-3">
-            {operationsHighlights.map((panel) => (
-              <article
-                key={panel.title}
-                className="flex flex-col gap-4 rounded-3xl border border-lundies-stone/60 bg-white/90 p-6 shadow-sm shadow-lundies-stone/40"
-              >
-                <h3 className="text-lg font-semibold text-lundies-charcoal">{panel.title}</h3>
-                <ul className="space-y-2 text-sm text-lundies-peat">
-                  {panel.bullets.map((bullet) => (
-                    <li key={bullet} className="rounded-full bg-lundies-linen px-3 py-2 text-lundies-charcoal">
-                      {bullet}
+          <div className="mt-16 grid gap-8 md:grid-cols-3" data-reveal>
+            {operationsHighlights.map((highlight) => (
+              <article key={highlight.title} className="space-y-5 rounded-[2rem] border border-lundies-stone/60 bg-white/80 p-6">
+                <h3 className="text-2xl">{highlight.title}</h3>
+                <ul className="space-y-3 text-sm text-lundies-peat">
+                  {highlight.points.map((point) => (
+                    <li key={point} className="flex items-start gap-3">
+                      <span aria-hidden="true" className="mt-1 inline-block h-1.5 w-1.5 rounded-full bg-lundies-moss" />
+                      <span>{point}</span>
                     </li>
                   ))}
                 </ul>
@@ -578,101 +512,111 @@ export default function Home() {
         </div>
       </section>
 
-      <section id="integrations" className="relative border-t border-lundies-stone/60 bg-white/70 py-20 backdrop-blur-sm">
-        <div className="mx-auto max-w-6xl px-6">
-          <SectionHeader
-            eyebrow="Ecosystem"
-            title="Integration runway"
-            description="Prioritised roadmap for critical channel, payment, messaging, and data services."
-            align="left"
-          />
-          <div className="mt-12 grid gap-6 md:grid-cols-2">
-            {integrationPartners.map((partner) => (
-              <article
-                key={partner.name}
-                className="rounded-3xl border border-lundies-stone/60 bg-white/90 p-6 shadow-sm shadow-lundies-stone/40"
+      <section id="awards" className="bg-white py-24">
+        <div className="mx-auto w-full max-w-5xl px-6">
+          <header className="max-w-xl space-y-4 text-center" data-reveal>
+            <p className="text-xs font-semibold uppercase tracking-[0.4em] text-lundies-moss">Recognition</p>
+            <h2 className="text-3xl sm:text-4xl">Awards & credentials</h2>
+            <p className="text-base text-lundies-peat">
+              Trusted accolades underscore the craft, sustainability, and welcome at the heart of Schiehallion.
+            </p>
+          </header>
+
+          <div className="mt-12 grid gap-6 sm:grid-cols-2" data-reveal>
+            {awards.map((award) => (
+              <div
+                key={award.label}
+                className="flex flex-col gap-2 rounded-[2rem] border border-lundies-stone/70 bg-lundies-linen/70 p-8 text-center"
               >
-                <h3 className="text-lg font-semibold text-lundies-charcoal">{partner.name}</h3>
-                <p className="mt-2 text-sm text-lundies-peat">{partner.focus}</p>
-                <div className="mt-4 flex flex-wrap gap-2 text-xs uppercase tracking-[0.25em] text-lundies-moss">
-                  <span className="rounded-full bg-lundies-linen px-3 py-1 text-lundies-charcoal">Priority · {partner.priority}</span>
-                  <span className="rounded-full bg-lundies-heather/30 px-3 py-1 text-lundies-charcoal">{partner.status}</span>
+                <span className="text-xs uppercase tracking-[0.4em] text-lundies-moss">{award.label}</span>
+                <span className="text-lg">{award.detail}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section id="contact" className="bg-lundies-ivory py-24">
+        <div className="mx-auto w-full max-w-6xl space-y-16 px-6">
+          <header className="max-w-2xl space-y-4" data-reveal>
+            <p className="text-xs font-semibold uppercase tracking-[0.4em] text-lundies-moss">Connect</p>
+            <h2 className="text-3xl sm:text-4xl">Let’s curate your Schiehallion stay</h2>
+            <p className="text-base text-lundies-peat">
+              Reach out to the team or launch the concierge to plan rooms, dining, and Aberfeldy adventures.
+            </p>
+          </header>
+
+          <div className="grid gap-10 md:grid-cols-[2fr,1fr]" data-reveal>
+            <div className="grid gap-6 sm:grid-cols-3">
+              {contactChannels.map((channel) => (
+                <div key={channel.label} className="space-y-2 rounded-[2rem] border border-lundies-stone/60 bg-white/80 p-6">
+                  <p className="text-xs uppercase tracking-[0.3em] text-lundies-moss">{channel.label}</p>
+                  <Link
+                    href={channel.href}
+                    className="text-lg leading-tight text-lundies-charcoal transition hover:text-lundies-peat"
+                  >
+                    {channel.detail}
+                  </Link>
                 </div>
-              </article>
-            ))}
-          </div>
-        </div>
-      </section>
+              ))}
+            </div>
 
-      <section
-        id="roadmap"
-        className="relative border-t border-lundies-stone/60 bg-gradient-to-b from-lundies-linen/90 to-lundies-stone/70 py-20"
-      >
-        <div className="mx-auto max-w-6xl px-6">
-          <SectionHeader
-            eyebrow="Delivery"
-            title="From blueprint to live guest journeys"
-            description="Phased plan aligning design sprints, engineering focus, and content production."
-          />
-          <div className="mt-12 grid gap-6 md:grid-cols-2">
-            {milestones.map((milestone) => (
-              <article
-                key={milestone.phase}
-                className="rounded-3xl border border-lundies-stone/60 bg-white/90 p-6 shadow-sm shadow-lundies-stone/40"
-              >
-                <h3 className="text-lg font-semibold text-lundies-charcoal">{milestone.phase}</h3>
-                <p className="mt-3 text-sm text-lundies-peat">{milestone.detail}</p>
-              </article>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      <section id="contact" className="relative border-t border-lundies-stone/60 bg-lundies-linen/80 py-20">
-        <div className="mx-auto max-w-5xl px-6 text-center">
-          <SectionHeader
-            eyebrow="Stay in touch"
-            title="Let’s craft the full Schiehallion experience"
-            description="Next steps: translate this vision into detailed component libraries, connect live data sources, and prepare usability tests with target guests."
-          />
-          <div className="mt-10 grid gap-6 text-sm text-lundies-peat sm:grid-cols-3">
-            <div className="rounded-3xl border border-lundies-stone/60 bg-white/90 p-6">
-              <p className="text-xs uppercase tracking-[0.25em] text-lundies-moss">Visit</p>
-              <p className="mt-3 text-sm text-lundies-charcoal">
-                6 Dunkeld Street
-                <br /> Aberfeldy, Perth & Kinross
-                <br /> PH15 2AF
+            <div className="space-y-4 rounded-[2rem] border border-lundies-stone/60 bg-white/80 p-6">
+              <h3 className="text-xl">Virtual Highland Host</h3>
+              <p className="text-sm text-lundies-peat">
+                Launch the concierge to craft itineraries, translate Gaelic welcomes, and arrange partner bookings.
               </p>
+              <Suspense fallback={<p className="text-sm text-lundies-peat">Loading concierge…</p>}>
+                <ConciergeChatWidget />
+              </Suspense>
             </div>
-            <div className="rounded-3xl border border-lundies-stone/60 bg-white/90 p-6">
-              <p className="text-xs uppercase tracking-[0.25em] text-lundies-moss">Call</p>
-              <p className="mt-3 text-lg font-semibold text-lundies-charcoal">01887 820421</p>
-              <p className="mt-2 text-xs text-lundies-peat">Front desk · 24/7</p>
-            </div>
-            <div className="rounded-3xl border border-lundies-stone/60 bg-white/90 p-6">
-              <p className="text-xs uppercase tracking-[0.25em] text-lundies-moss">Write</p>
-              <p className="mt-3 text-sm text-lundies-charcoal">bookings@schiehallionhotel.co.uk</p>
-              <p className="mt-2 text-xs text-lundies-peat">Booking enquiries & partnerships</p>
-            </div>
-          </div>
-          <div className="mt-12 flex flex-wrap justify-center gap-4 text-xs uppercase tracking-[0.25em] text-lundies-moss">
-            <span className="rounded-full border border-lundies-stone/60 px-4 py-2">Phase 0 Prototype</span>
-            <span className="rounded-full border border-lundies-stone/60 px-4 py-2">WCAG-first layout</span>
-            <span className="rounded-full border border-lundies-stone/60 px-4 py-2">Mobile friendly</span>
           </div>
         </div>
       </section>
 
-      <footer className="border-t border-lundies-stone/60 bg-lundies-stone/60 py-10 text-xs text-lundies-charcoal">
-        <div className="mx-auto flex max-w-6xl flex-col gap-3 px-6 sm:flex-row sm:items-center sm:justify-between">
-          <p>© {new Date().getFullYear()} Schiehallion Hotel · Perthshire, Scotland</p>
-          <p>Part of the Nano Banana hospitality stack initiative.</p>
+      <footer className="border-t border-lundies-stone/60 bg-white/80">
+        <div className="mx-auto flex w-full max-w-6xl flex-col gap-8 px-6 py-12 text-sm text-lundies-peat md:flex-row md:items-center md:justify-between">
+          <div>
+            <p className="font-semibold text-lundies-charcoal">Schiehallion Hotel</p>
+            <p className="mt-1">Luxury in the heart of Aberfeldy since 1870.</p>
+          </div>
+          <div className="flex flex-wrap gap-6">
+            <Link href="/privacy" className="transition hover:text-lundies-charcoal">
+              Privacy
+            </Link>
+            <Link href="/terms" className="transition hover:text-lundies-charcoal">
+              Terms
+            </Link>
+            <Link href="/rooms" className="transition hover:text-lundies-charcoal">
+              Rooms
+            </Link>
+            <Link href="/restaurant" className="transition hover:text-lundies-charcoal">
+              Dining
+            </Link>
+          </div>
+          <p className="text-xs uppercase tracking-[0.3em] text-lundies-peat/70">Design · Photography · Hospitality</p>
         </div>
       </footer>
 
-      <Suspense fallback={null}>
-        <ConciergeChatWidget />
-      </Suspense>
+      {!user && showLogin ? (
+        <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/60 p-4 backdrop-blur-sm">
+          <div className="relative w-full max-w-md space-y-6 rounded-3xl border border-lundies-stone/60 bg-white/95 p-8 shadow-2xl">
+            <button
+              type="button"
+              onClick={() => setShowLogin(false)}
+              className="absolute right-4 top-4 rounded-full border border-lundies-stone/60 px-3 py-1 text-xs uppercase tracking-[0.3em] text-lundies-charcoal transition hover:bg-lundies-stone/30"
+              aria-label="Close login"
+            >
+              Close
+            </button>
+            <div className="text-center">
+              <h2 className="text-2xl text-lundies-charcoal">Welcome back</h2>
+              <p className="mt-2 text-sm text-lundies-peat">Sign in to manage bookings and staff tools.</p>
+            </div>
+            <LoginForm />
+          </div>
+        </div>
+      ) : null}
     </main>
   )
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,233 +1,42 @@
 'use client'
 
-import Image from 'next/image'
 import Link from 'next/link'
-import { lazy, Suspense, useEffect, useMemo, useState } from 'react'
+import { lazy, useEffect, useState } from 'react'
 
+import ErrorBoundary from '@/components/ErrorBoundary'
+import AwardsSection from '@/components/landing/AwardsSection'
+import ContactSection from '@/components/landing/ContactSection'
+import DiningSection from '@/components/landing/DiningSection'
+import ExperiencesSection from '@/components/landing/ExperiencesSection'
+import HeroSection from '@/components/landing/HeroSection'
+import OperationsSection from '@/components/landing/OperationsSection'
+import RoomsSection from '@/components/landing/RoomsSection'
+import TechnologySection from '@/components/landing/TechnologySection'
 import LoginForm from '@/components/LoginForm'
 import SiteNavigation from '@/components/navigation/SiteNavigation'
+import { contactChannels } from '@/config/contact'
 import { useAuth } from '@/context/AuthContext'
+import {
+  awards,
+  diningMoments,
+  experienceStories,
+  heroImages,
+  landingSections,
+  operationsHighlights,
+  roomCollections,
+  technologyPillars,
+} from '@/data/landing'
+import { usePrefersReducedMotion } from '@/hooks/usePrefersReducedMotion'
+import { useRevealOnScroll } from '@/hooks/useRevealOnScroll'
 
 const ConciergeChatWidget = lazy(() => import('@/components/concierge/ConciergeChatWidget'))
-
-const landingSections = [
-  { label: 'Story', href: '#story' },
-  { label: 'Rooms', href: '#rooms' },
-  { label: 'Dining', href: '#dining' },
-  { label: 'Experiences', href: '#experiences' },
-  { label: 'Technology', href: '#technology' },
-  { label: 'Operations', href: '#operations' },
-  { label: 'Awards', href: '#awards' },
-  { label: 'Contact', href: '#contact' },
-]
-
-const heroImages = [
-  {
-    src: '/images/rooms/generated/suite/suite-artistic-1759248824246-ur9015.png',
-    alt: 'Soft morning light inside the Schiehallion loft suite',
-    caption: 'Loch Tay suites with tailored service',
-  },
-  {
-    src: '/images/rooms/generated/deluxe/deluxe-artistic-1759248801864-outd2c.png',
-    alt: 'Deluxe room featuring freestanding bath and herringbone floors',
-    caption: 'Deluxe comforts with Highland textures',
-  },
-  {
-    src: '/images/rooms/generated/family/family-artistic-1759248840189-b78zgy.png',
-    alt: 'Family suite with warm timber panelling and seating nook',
-    caption: 'Family suites crafted for together time',
-  },
-]
-
-const roomCollections = [
-  {
-    name: 'Highland View Double',
-    summary: 'Loch-side calm, super-king sleep, fresh pastries on cue.',
-    image: '/images/rooms/generated/standard/standard-artistic-1759248767421-r0mln6.png',
-    meta: 'Signature Double · 2 adults + child',
-  },
-  {
-    name: 'Riverside Twin Retreat',
-    summary: 'Twin comfort with ergonomic workspace and ultrafast Wi-Fi.',
-    image: '/images/rooms/generated/accessible/accessible-artistic-1759248857443-57441r.png',
-    meta: 'Twin · Work-ready sanctuary',
-  },
-  {
-    name: 'Family Cairngorm Suite',
-    summary: 'Interconnected rooms, games chest, and concierge planning.',
-    image: '/images/rooms/generated/family/family-artistic-1759248840189-b78zgy.png',
-    meta: 'Two-bedroom suite · 2 adults · 2 children',
-  },
-  {
-    name: 'Deluxe Schiehallion Loft',
-    summary: 'Freestanding bath, private check-in, telescope over Ben Lawers.',
-    image: '/images/rooms/generated/deluxe/deluxe-artistic-1759248801864-outd2c.png',
-    meta: 'Loft suite · Celebrations',
-  },
-]
-
-const diningMoments = [
-  {
-    title: 'The Schiehallion Kitchen',
-    description: 'Seasonal tasting journeys with Perthshire produce and sommelier pairings.',
-    image: '/images/rooms/generated/suite/suite-artistic-1759248824246-ur9015.png',
-    highlights: ['Four-course tasting', 'Vegan pairings', 'Wine flights'],
-  },
-  {
-    title: 'Breakfast & Brunch',
-    description: 'Sunrise spreads, Glen Lyon coffee, and take-away baskets for river guides.',
-    image: '/images/rooms/generated/standard/standard-artistic-1759248767421-r0mln6.png',
-    highlights: ['Fresh pastries', 'Express takeaway', 'Locally roasted beans'],
-  },
-  {
-    title: 'Afternoon Rituals',
-    description: 'Highland shortbread towers, live roast countdown, patisserie made in-house.',
-    image: '/images/rooms/generated/accessible/accessible-artistic-1759248857443-57441r.png',
-    highlights: ['Seasonal tea menu', 'Allergen aware', 'Sunday roast theatre'],
-  },
-]
-
-const experienceStories = [
-  {
-    name: 'Dewars Aberfeldy Distillery',
-    distance: '2 miles',
-    description: 'Heritage tastings, storytelling lounges, bespoke whisky flights.',
-  },
-  {
-    name: 'Beyond Adventure',
-    distance: 'On the River Tay',
-    description: 'Kayaking, paddleboarding, and private guides for every level.',
-  },
-  {
-    name: 'Loch Tay & Ben Lawers',
-    distance: '15 minutes',
-    description: 'Sunrise hikes, photographer-led expeditions, snowline picnics.',
-  },
-  {
-    name: 'Aberfeldy Watermill & Gallery',
-    distance: '5 minute walk',
-    description: 'Independent bookshop, art exhibitions, slow-travel inspiration.',
-  },
-]
-
-const technologyPillars = [
-  {
-    title: 'Unified Booking Surface',
-    detail:
-      'Next.js 15 powering responsive web, PWA, and admin journeys with shared tokens and inclusive patterns.',
-  },
-  {
-    title: 'Real-time Availability Core',
-    detail: 'Firestore + Realtime Database syncing room calendars, dining tables, and partner allotments.',
-  },
-  {
-    title: 'Edge-first Performance',
-    detail: 'CDN image optimisation, caching strategies, and sub-100ms first content worldwide.',
-  },
-  {
-    title: 'Payments & Assurance',
-    detail: 'Stripe integrations with 3D Secure, automated confirmations, and audit-ready histories.',
-  },
-]
-
-const operationsHighlights = [
-  {
-    title: 'Operations Command Centre',
-    points: ['Drag-and-drop room assignment', 'Housekeeping snapshots', 'Proactive maintenance alerts'],
-  },
-  {
-    title: 'Revenue Studio',
-    points: ['Dynamic pricing experiments', 'Package performance analytics', 'Competitive benchmarks'],
-  },
-  {
-    title: 'Guest Relationship Desk',
-    points: ['Unified inbox', 'Pre-arrival and post-stay flows', 'Loyalty segmentation'],
-  },
-]
-
-const awards = [
-  { label: 'Scottish Hotel Awards', detail: 'Boutique Hotel of the Year · 2023' },
-  { label: 'Green Key Certification', detail: 'Sustainable operations accreditation' },
-  { label: 'VisitScotland', detail: '5-Star Gold Guest Accommodation' },
-  { label: 'Condé Nast Traveller', detail: 'Readers Choice Top 20 Highlands' },
-]
-
-const contactChannels = [
-  { label: 'Visit', detail: '1-5 Dunkeld Street, Aberfeldy, PH15 2AA', href: 'https://maps.app.goo.gl/qxgTB1gYkn12' },
-  { label: 'Reserve', detail: '+44 (0)1887 352 214', href: 'tel:+441887352214' },
-  { label: 'Enquire', detail: 'hello@schiehallionhotel.co.uk', href: 'mailto:hello@schiehallionhotel.co.uk' },
-]
-
-function usePrefersReducedMotion() {
-  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false)
-
-  useEffect(() => {
-    if (typeof window === 'undefined') return
-
-    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)')
-    const handleChange = () => setPrefersReducedMotion(mediaQuery.matches)
-
-    handleChange()
-    mediaQuery.addEventListener('change', handleChange)
-
-    return () => mediaQuery.removeEventListener('change', handleChange)
-  }, [])
-
-  return prefersReducedMotion
-}
 
 export default function Home() {
   const { user } = useAuth()
   const prefersReducedMotion = usePrefersReducedMotion()
-  const [activeHero, setActiveHero] = useState(0)
   const [showLogin, setShowLogin] = useState(false)
 
-  useEffect(() => {
-    if (prefersReducedMotion) return
-
-    const timer = window.setInterval(() => {
-      setActiveHero((current) => (current + 1) % heroImages.length)
-    }, 7000)
-
-    return () => window.clearInterval(timer)
-  }, [prefersReducedMotion])
-
-  useEffect(() => {
-    if (typeof window === 'undefined') return
-
-    const revealElements = document.querySelectorAll<HTMLElement>('[data-reveal]')
-
-    if (!revealElements.length) return
-
-    if (prefersReducedMotion) {
-      revealElements.forEach((element) => {
-        element.classList.add('reveal-visible')
-      })
-      return
-    }
-
-    revealElements.forEach((element) => {
-      element.classList.add('reveal-element')
-    })
-
-    const observer = new IntersectionObserver(
-      (entries, obs) => {
-        entries.forEach((entry) => {
-          if (entry.isIntersecting) {
-            entry.target.classList.add('reveal-visible')
-            obs.unobserve(entry.target)
-          }
-        })
-      },
-      { threshold: 0.15, rootMargin: '0px 0px -10% 0px' },
-    )
-
-    revealElements.forEach((element) => observer.observe(element))
-
-    return () => observer.disconnect()
-  }, [prefersReducedMotion])
-
-  const heroCaptions = useMemo(() => heroImages.map((image) => image.caption), [])
+  useRevealOnScroll(prefersReducedMotion)
 
   useEffect(() => {
     if (!showLogin) return
@@ -274,305 +83,27 @@ export default function Home() {
         }
       />
 
-      <section
-        id="story"
-        className="relative flex min-h-[90vh] flex-col justify-end overflow-hidden border-b border-lundies-stone/40 bg-black/60"
-      >
-        <div className="absolute inset-0">
-          {heroImages.map((image, index) => (
-            <Image
-              key={image.src}
-              src={image.src}
-              alt={image.alt}
-              fill
-              priority={index === 0}
-              sizes="100vw"
-              className={`object-cover transition-opacity duration-[1200ms] ease-out ${
-                index === activeHero ? 'opacity-100' : 'opacity-0'
-              }`}
-            />
-          ))}
-          <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/20 to-black/60" />
-        </div>
-
-        <div className="relative mx-auto flex w-full max-w-6xl flex-col gap-10 px-6 pb-24 pt-32 text-white">
-          <div className="max-w-3xl space-y-6" data-reveal>
-            <p className="text-xs font-semibold uppercase tracking-[0.45em] text-white/70">Aberfeldy, Scotland</p>
-            <h1 className="text-4xl leading-tight sm:text-5xl lg:text-6xl">
-              A minimalist canvas for luxury Highland hospitality
-            </h1>
-            <p className="max-w-xl text-base text-white/80 sm:text-lg">
-              We distilled the Schiehallion experience into a single flowing page: cinematic imagery, crafted typography, and a
-              calm rhythm from arrival to farewell.
-            </p>
-            <div className="flex flex-wrap gap-3">
-              <Link
-                href="/booking"
-                className="rounded-full bg-white px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-lundies-charcoal transition hover:bg-white/90"
-              >
-                Book your stay
-              </Link>
-              <Link
-                href="#rooms"
-                className="rounded-full border border-white/40 px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-white transition hover:border-white hover:bg-white/10"
-              >
-                Explore rooms
-              </Link>
-            </div>
-          </div>
-
-          <div className="flex items-end justify-between" data-reveal>
-            <div>
-              <p className="text-sm uppercase tracking-[0.35em] text-white/70">Now featuring</p>
-              <p className="mt-3 text-lg font-light text-white">
-                {heroCaptions[activeHero]}
-              </p>
-            </div>
-            <div className="hidden items-center gap-4 sm:flex">
-              <span className="text-xs uppercase tracking-[0.3em] text-white/50">Scroll</span>
-              <div className="scroll-indicator" aria-hidden="true" />
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <section id="rooms" className="bg-lundies-ivory py-24">
-        <div className="mx-auto flex w-full max-w-6xl flex-col gap-12 px-6">
-          <header className="max-w-2xl space-y-4" data-reveal>
-            <p className="text-xs font-semibold uppercase tracking-[0.4em] text-lundies-moss">Rooms & suites</p>
-            <h2 className="text-3xl sm:text-4xl">Tailored stays for every travel story</h2>
-            <p className="text-base text-lundies-peat">
-              Each room is staged for photography, future availability widgets, and campaign-ready storytelling.
-            </p>
-          </header>
-
-          <div className="space-y-16">
-            {roomCollections.map((room, index) => (
-              <article
-                key={room.name}
-                className={`grid gap-10 md:grid-cols-2 md:items-center ${index % 2 === 1 ? 'md:grid-flow-col-dense' : ''}`}
-              >
-                <div className="relative aspect-[4/3] overflow-hidden rounded-[2.5rem] bg-lundies-stone/40" data-reveal>
-                  <Image
-                    src={room.image}
-                    alt={room.name}
-                    fill
-                    sizes="(min-width: 768px) 50vw, 100vw"
-                    className="object-cover"
-                    loading={index === 0 ? 'eager' : 'lazy'}
-                  />
-                </div>
-                <div className="space-y-6" data-reveal>
-                  <p className="text-xs uppercase tracking-[0.4em] text-lundies-moss">{room.meta}</p>
-                  <h3 className="text-3xl">{room.name}</h3>
-                  <p className="text-base text-lundies-peat">{room.summary}</p>
-                  <div className="flex flex-wrap gap-3">
-                    <Link
-                      href="/rooms"
-                      className="rounded-full border border-lundies-stone px-5 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-lundies-charcoal transition hover:bg-white"
-                    >
-                      Room details
-                    </Link>
-                    <Link
-                      href="/booking"
-                      className="rounded-full bg-lundies-heather px-5 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-lundies-charcoal transition hover:bg-lundies-heather/80"
-                    >
-                      Check availability
-                    </Link>
-                  </div>
-                </div>
-              </article>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      <section id="dining" className="bg-white py-24">
-        <div className="mx-auto w-full max-w-6xl px-6">
-          <header className="max-w-2xl space-y-4" data-reveal>
-            <p className="text-xs font-semibold uppercase tracking-[0.4em] text-lundies-moss">Dining journey</p>
-            <h2 className="text-3xl sm:text-4xl">Culinary moments paced through the day</h2>
-            <p className="text-base text-lundies-peat">
-              Menus that celebrate Perthshire produce with immersive photography ready for story-led campaigns.
-            </p>
-          </header>
-
-          <div className="mt-16 grid gap-12 md:grid-cols-3">
-            {diningMoments.map((moment) => (
-              <article key={moment.title} className="space-y-6" data-reveal>
-                <div className="relative aspect-[3/4] overflow-hidden rounded-[2rem] bg-lundies-stone/30">
-                  <Image
-                    src={moment.image}
-                    alt={moment.title}
-                    fill
-                    sizes="(min-width: 768px) 33vw, 100vw"
-                    className="object-cover"
-                    loading="lazy"
-                  />
-                </div>
-                <div className="space-y-3">
-                  <h3 className="text-2xl">{moment.title}</h3>
-                  <p className="text-sm text-lundies-peat">{moment.description}</p>
-                  <ul className="space-y-2 text-xs uppercase tracking-[0.3em] text-lundies-moss">
-                    {moment.highlights.map((highlight) => (
-                      <li key={highlight} className="flex items-center justify-between border-b border-lundies-stone/50 pb-2">
-                        <span>{highlight}</span>
-                        <span className="text-lundies-charcoal/50">Soon in app</span>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              </article>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      <section id="experiences" className="bg-lundies-ivory py-24">
-        <div className="mx-auto w-full max-w-6xl space-y-12 px-6">
-          <header className="max-w-2xl space-y-4" data-reveal>
-            <p className="text-xs font-semibold uppercase tracking-[0.4em] text-lundies-moss">Experiences</p>
-            <h2 className="text-3xl sm:text-4xl">Curated adventures around Aberfeldy</h2>
-            <p className="text-base text-lundies-peat">
-              Designed as swipeable stories with partner integrations and live availability hooks.
-            </p>
-          </header>
-
-          <div
-            className="flex gap-8 overflow-x-auto pb-4"
-            data-reveal
-            role="list"
-            aria-label="Experience highlights"
-          >
-            {experienceStories.map((experience) => (
-              <div
-                key={experience.name}
-                role="listitem"
-                className="min-w-[260px] max-w-xs flex-1 space-y-4 rounded-[2rem] border border-lundies-stone/60 bg-white/70 p-6 backdrop-blur"
-              >
-                <p className="text-xs uppercase tracking-[0.3em] text-lundies-moss">{experience.distance}</p>
-                <h3 className="text-2xl">{experience.name}</h3>
-                <p className="text-sm text-lundies-peat">{experience.description}</p>
-                <span className="text-xs uppercase tracking-[0.3em] text-lundies-charcoal/60">Concierge ready</span>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      <section id="technology" className="bg-white py-24">
-        <div className="mx-auto w-full max-w-6xl px-6">
-          <header className="max-w-2xl space-y-4" data-reveal>
-            <p className="text-xs font-semibold uppercase tracking-[0.4em] text-lundies-moss">Technology</p>
-            <h2 className="text-3xl sm:text-4xl">The platform behind the poise</h2>
-            <p className="text-base text-lundies-peat">
-              Modular services keep the guest journey quick, personalised, and future-friendly.
-            </p>
-          </header>
-
-          <div className="mt-16 grid gap-8 md:grid-cols-2" data-reveal>
-            {technologyPillars.map((pillar) => (
-              <article
-                key={pillar.title}
-                className="space-y-4 rounded-[2rem] border border-lundies-stone/60 bg-lundies-linen/80 p-8 shadow-sm"
-              >
-                <h3 className="text-2xl">{pillar.title}</h3>
-                <p className="text-sm text-lundies-peat">{pillar.detail}</p>
-              </article>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      <section id="operations" className="bg-lundies-ivory py-24">
-        <div className="mx-auto w-full max-w-6xl px-6">
-          <header className="max-w-2xl space-y-4" data-reveal>
-            <p className="text-xs font-semibold uppercase tracking-[0.4em] text-lundies-moss">Operations</p>
-            <h2 className="text-3xl sm:text-4xl">Empowering teams behind the scenes</h2>
-            <p className="text-base text-lundies-peat">
-              Interfaces choreographed for operations, revenue, and guest relations to collaborate in real time.
-            </p>
-          </header>
-
-          <div className="mt-16 grid gap-8 md:grid-cols-3" data-reveal>
-            {operationsHighlights.map((highlight) => (
-              <article key={highlight.title} className="space-y-5 rounded-[2rem] border border-lundies-stone/60 bg-white/80 p-6">
-                <h3 className="text-2xl">{highlight.title}</h3>
-                <ul className="space-y-3 text-sm text-lundies-peat">
-                  {highlight.points.map((point) => (
-                    <li key={point} className="flex items-start gap-3">
-                      <span aria-hidden="true" className="mt-1 inline-block h-1.5 w-1.5 rounded-full bg-lundies-moss" />
-                      <span>{point}</span>
-                    </li>
-                  ))}
-                </ul>
-              </article>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      <section id="awards" className="bg-white py-24">
-        <div className="mx-auto w-full max-w-5xl px-6">
-          <header className="max-w-xl space-y-4 text-center" data-reveal>
-            <p className="text-xs font-semibold uppercase tracking-[0.4em] text-lundies-moss">Recognition</p>
-            <h2 className="text-3xl sm:text-4xl">Awards & credentials</h2>
-            <p className="text-base text-lundies-peat">
-              Trusted accolades underscore the craft, sustainability, and welcome at the heart of Schiehallion.
-            </p>
-          </header>
-
-          <div className="mt-12 grid gap-6 sm:grid-cols-2" data-reveal>
-            {awards.map((award) => (
-              <div
-                key={award.label}
-                className="flex flex-col gap-2 rounded-[2rem] border border-lundies-stone/70 bg-lundies-linen/70 p-8 text-center"
-              >
-                <span className="text-xs uppercase tracking-[0.4em] text-lundies-moss">{award.label}</span>
-                <span className="text-lg">{award.detail}</span>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      <section id="contact" className="bg-lundies-ivory py-24">
-        <div className="mx-auto w-full max-w-6xl space-y-16 px-6">
-          <header className="max-w-2xl space-y-4" data-reveal>
-            <p className="text-xs font-semibold uppercase tracking-[0.4em] text-lundies-moss">Connect</p>
-            <h2 className="text-3xl sm:text-4xl">Let’s curate your Schiehallion stay</h2>
-            <p className="text-base text-lundies-peat">
-              Reach out to the team or launch the concierge to plan rooms, dining, and Aberfeldy adventures.
-            </p>
-          </header>
-
-          <div className="grid gap-10 md:grid-cols-[2fr,1fr]" data-reveal>
-            <div className="grid gap-6 sm:grid-cols-3">
-              {contactChannels.map((channel) => (
-                <div key={channel.label} className="space-y-2 rounded-[2rem] border border-lundies-stone/60 bg-white/80 p-6">
-                  <p className="text-xs uppercase tracking-[0.3em] text-lundies-moss">{channel.label}</p>
-                  <Link
-                    href={channel.href}
-                    className="text-lg leading-tight text-lundies-charcoal transition hover:text-lundies-peat"
-                  >
-                    {channel.detail}
-                  </Link>
-                </div>
-              ))}
-            </div>
-
-            <div className="space-y-4 rounded-[2rem] border border-lundies-stone/60 bg-white/80 p-6">
-              <h3 className="text-xl">Virtual Highland Host</h3>
+      <HeroSection heroImages={heroImages} prefersReducedMotion={prefersReducedMotion} />
+      <RoomsSection rooms={roomCollections} />
+      <DiningSection moments={diningMoments} />
+      <ExperiencesSection experiences={experienceStories} />
+      <TechnologySection pillars={technologyPillars} />
+      <OperationsSection highlights={operationsHighlights} />
+      <AwardsSection awards={awards} />
+      <ContactSection
+        channels={contactChannels}
+        conciergeWidget={
+          <ErrorBoundary
+            fallback={
               <p className="text-sm text-lundies-peat">
-                Launch the concierge to craft itineraries, translate Gaelic welcomes, and arrange partner bookings.
+                Concierge widget unavailable. Please contact us directly.
               </p>
-              <Suspense fallback={<p className="text-sm text-lundies-peat">Loading concierge…</p>}>
-                <ConciergeChatWidget />
-              </Suspense>
-            </div>
-          </div>
-        </div>
-      </section>
+            }
+          >
+            <ConciergeChatWidget />
+          </ErrorBoundary>
+        }
+      />
 
       <footer className="border-t border-lundies-stone/60 bg-white/80">
         <div className="mx-auto flex w-full max-w-6xl flex-col gap-8 px-6 py-12 text-sm text-lundies-peat md:flex-row md:items-center md:justify-between">

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import { Component, type ReactNode } from 'react'
+
+interface Props {
+  children: ReactNode
+  fallback?: ReactNode
+}
+
+interface State {
+  hasError: boolean
+  error?: Error
+}
+
+export default class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props)
+    this.state = { hasError: false }
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error }
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    console.error('ErrorBoundary caught an error:', error, errorInfo)
+  }
+
+  render() {
+    if (this.state.hasError) {
+      if (this.props.fallback) {
+        return this.props.fallback
+      }
+
+      return (
+        <div className="rounded-2xl border border-lundies-stone/60 bg-lundies-linen/50 p-6 text-center">
+          <p className="text-sm text-lundies-peat">
+            Something went wrong loading this component. Please refresh the page.
+          </p>
+        </div>
+      )
+    }
+
+    return this.props.children
+  }
+}

--- a/src/components/landing/AwardsSection.tsx
+++ b/src/components/landing/AwardsSection.tsx
@@ -1,0 +1,33 @@
+import type { awards } from '@/data/landing'
+
+interface AwardsSectionProps {
+  awards: typeof awards
+}
+
+export default function AwardsSection({ awards }: AwardsSectionProps) {
+  return (
+    <section id="awards" className="bg-white py-24">
+      <div className="mx-auto w-full max-w-5xl px-6">
+        <header className="max-w-xl space-y-4 text-center" data-reveal>
+          <p className="text-xs font-semibold uppercase tracking-[0.4em] text-lundies-moss">Recognition</p>
+          <h2 className="text-3xl sm:text-4xl">Awards & credentials</h2>
+          <p className="text-base text-lundies-peat">
+            Trusted accolades underscore the craft, sustainability, and welcome at the heart of Schiehallion.
+          </p>
+        </header>
+
+        <div className="mt-12 grid gap-6 sm:grid-cols-2" data-reveal>
+          {awards.map((award) => (
+            <div
+              key={award.label}
+              className="flex flex-col gap-2 rounded-[2rem] border border-lundies-stone/70 bg-lundies-linen/70 p-8 text-center"
+            >
+              <span className="text-xs uppercase tracking-[0.4em] text-lundies-moss">{award.label}</span>
+              <span className="text-lg">{award.detail}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/components/landing/ContactSection.tsx
+++ b/src/components/landing/ContactSection.tsx
@@ -1,0 +1,58 @@
+import Link from 'next/link'
+import { Suspense } from 'react'
+
+import type { contactChannels } from '@/config/contact'
+
+interface ContactSectionProps {
+  channels: typeof contactChannels
+  conciergeWidget: React.ReactNode
+}
+
+export default function ContactSection({ channels, conciergeWidget }: ContactSectionProps) {
+  return (
+    <section id="contact" className="bg-lundies-ivory py-24">
+      <div className="mx-auto w-full max-w-6xl space-y-16 px-6">
+        <header className="max-w-2xl space-y-4" data-reveal>
+          <p className="text-xs font-semibold uppercase tracking-[0.4em] text-lundies-moss">Connect</p>
+          <h2 className="text-3xl sm:text-4xl">Let's curate your Schiehallion stay</h2>
+          <p className="text-base text-lundies-peat">
+            Reach out to the team or launch the concierge to plan rooms, dining, and Aberfeldy adventures.
+          </p>
+        </header>
+
+        <div className="grid gap-10 md:grid-cols-[2fr,1fr]" data-reveal>
+          <div className="grid gap-6 sm:grid-cols-3">
+            {channels.map((channel) => (
+              <div key={channel.label} className="space-y-2 rounded-[2rem] border border-lundies-stone/60 bg-white/80 p-6">
+                <p className="text-xs uppercase tracking-[0.3em] text-lundies-moss">{channel.label}</p>
+                <Link
+                  href={channel.href}
+                  className="text-lg leading-tight text-lundies-charcoal transition hover:text-lundies-peat"
+                >
+                  {channel.detail}
+                </Link>
+              </div>
+            ))}
+          </div>
+
+          <div className="space-y-4 rounded-[2rem] border border-lundies-stone/60 bg-white/80 p-6">
+            <h3 className="text-xl">Virtual Highland Host</h3>
+            <p className="text-sm text-lundies-peat">
+              Launch the concierge to craft itineraries, translate Gaelic welcomes, and arrange partner bookings.
+            </p>
+            <Suspense
+              fallback={
+                <div className="flex items-center gap-2 text-sm text-lundies-peat">
+                  <div className="h-4 w-4 animate-spin rounded-full border-2 border-lundies-moss border-t-transparent" />
+                  <span>Loading concierge…</span>
+                </div>
+              }
+            >
+              {conciergeWidget}
+            </Suspense>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/components/landing/DiningSection.tsx
+++ b/src/components/landing/DiningSection.tsx
@@ -1,0 +1,52 @@
+import Image from 'next/image'
+
+import type { diningMoments } from '@/data/landing'
+
+interface DiningSectionProps {
+  moments: typeof diningMoments
+}
+
+export default function DiningSection({ moments }: DiningSectionProps) {
+  return (
+    <section id="dining" className="bg-white py-24">
+      <div className="mx-auto w-full max-w-6xl px-6">
+        <header className="max-w-2xl space-y-4" data-reveal>
+          <p className="text-xs font-semibold uppercase tracking-[0.4em] text-lundies-moss">Dining journey</p>
+          <h2 className="text-3xl sm:text-4xl">Culinary moments paced through the day</h2>
+          <p className="text-base text-lundies-peat">
+            Menus that celebrate Perthshire produce with immersive photography ready for story-led campaigns.
+          </p>
+        </header>
+
+        <div className="mt-16 grid gap-12 md:grid-cols-3">
+          {moments.map((moment) => (
+            <article key={moment.title} className="space-y-6" data-reveal>
+              <div className="relative aspect-[3/4] overflow-hidden rounded-[2rem] bg-lundies-stone/30">
+                <Image
+                  src={moment.image}
+                  alt={moment.title}
+                  fill
+                  sizes="(min-width: 768px) 33vw, 100vw"
+                  className="object-cover"
+                  loading="lazy"
+                />
+              </div>
+              <div className="space-y-3">
+                <h3 className="text-2xl">{moment.title}</h3>
+                <p className="text-sm text-lundies-peat">{moment.description}</p>
+                <ul className="space-y-2 text-xs uppercase tracking-[0.3em] text-lundies-moss">
+                  {moment.highlights.map((highlight) => (
+                    <li key={highlight} className="flex items-center justify-between border-b border-lundies-stone/50 pb-2">
+                      <span>{highlight}</span>
+                      <span className="text-lundies-charcoal/50">Soon in app</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/components/landing/ExperiencesSection.tsx
+++ b/src/components/landing/ExperiencesSection.tsx
@@ -1,0 +1,41 @@
+import type { experienceStories } from '@/data/landing'
+
+interface ExperiencesSectionProps {
+  experiences: typeof experienceStories
+}
+
+export default function ExperiencesSection({ experiences }: ExperiencesSectionProps) {
+  return (
+    <section id="experiences" className="bg-lundies-ivory py-24">
+      <div className="mx-auto w-full max-w-6xl space-y-12 px-6">
+        <header className="max-w-2xl space-y-4" data-reveal>
+          <p className="text-xs font-semibold uppercase tracking-[0.4em] text-lundies-moss">Experiences</p>
+          <h2 className="text-3xl sm:text-4xl">Curated adventures around Aberfeldy</h2>
+          <p className="text-base text-lundies-peat">
+            Designed as swipeable stories with partner integrations and live availability hooks.
+          </p>
+        </header>
+
+        <div
+          className="flex gap-8 overflow-x-auto pb-4"
+          data-reveal
+          role="list"
+          aria-label="Experience highlights"
+        >
+          {experiences.map((experience) => (
+            <div
+              key={experience.name}
+              role="listitem"
+              className="min-w-[260px] max-w-xs flex-1 space-y-4 rounded-[2rem] border border-lundies-stone/60 bg-white/70 p-6 backdrop-blur"
+            >
+              <p className="text-xs uppercase tracking-[0.3em] text-lundies-moss">{experience.distance}</p>
+              <h3 className="text-2xl">{experience.name}</h3>
+              <p className="text-sm text-lundies-peat">{experience.description}</p>
+              <span className="text-xs uppercase tracking-[0.3em] text-lundies-charcoal/60">Concierge ready</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/components/landing/HeroSection.tsx
+++ b/src/components/landing/HeroSection.tsx
@@ -1,0 +1,90 @@
+'use client'
+
+import Image from 'next/image'
+import Link from 'next/link'
+import { useEffect, useState } from 'react'
+
+import type { heroImages } from '@/data/landing'
+
+interface HeroSectionProps {
+  heroImages: typeof heroImages
+  prefersReducedMotion: boolean
+}
+
+export default function HeroSection({ heroImages, prefersReducedMotion }: HeroSectionProps) {
+  const [activeHero, setActiveHero] = useState(0)
+
+  useEffect(() => {
+    if (prefersReducedMotion) return
+
+    const timer = window.setInterval(() => {
+      setActiveHero((current) => (current + 1) % heroImages.length)
+    }, 7000)
+
+    return () => window.clearInterval(timer)
+  }, [prefersReducedMotion, heroImages.length])
+
+  const heroCaptions = heroImages.map((image) => image.caption)
+
+  return (
+    <section
+      id="story"
+      className="relative flex min-h-[90vh] flex-col justify-end overflow-hidden border-b border-lundies-stone/40 bg-black/60"
+    >
+      <div className="absolute inset-0">
+        {heroImages.map((image, index) => (
+          <Image
+            key={image.src}
+            src={image.src}
+            alt={image.alt}
+            fill
+            priority={index === 0}
+            sizes="100vw"
+            className={`object-cover transition-opacity duration-[1200ms] ease-out ${
+              index === activeHero ? 'opacity-100' : 'opacity-0'
+            }`}
+          />
+        ))}
+        <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/20 to-black/60" />
+      </div>
+
+      <div className="relative mx-auto flex w-full max-w-6xl flex-col gap-10 px-6 pb-24 pt-32 text-white">
+        <div className="max-w-3xl space-y-6" data-reveal>
+          <p className="text-xs font-semibold uppercase tracking-[0.45em] text-white/70">Aberfeldy, Scotland</p>
+          <h1 className="text-4xl leading-tight sm:text-5xl lg:text-6xl">
+            A minimalist canvas for luxury Highland hospitality
+          </h1>
+          <p className="max-w-xl text-base text-white/80 sm:text-lg">
+            We distilled the Schiehallion experience into a single flowing page: cinematic imagery, crafted typography, and a
+            calm rhythm from arrival to farewell.
+          </p>
+          <div className="flex flex-wrap gap-3">
+            <Link
+              href="/booking"
+              className="rounded-full bg-white px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-lundies-charcoal transition hover:bg-white/90"
+            >
+              Book your stay
+            </Link>
+            <Link
+              href="#rooms"
+              className="rounded-full border border-white/40 px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-white transition hover:border-white hover:bg-white/10"
+            >
+              Explore rooms
+            </Link>
+          </div>
+        </div>
+
+        <div className="flex items-end justify-between" data-reveal>
+          <div>
+            <p className="text-sm uppercase tracking-[0.35em] text-white/70">Now featuring</p>
+            <p className="mt-3 text-lg font-light text-white">{heroCaptions[activeHero]}</p>
+          </div>
+          <div className="hidden items-center gap-4 sm:flex">
+            <span className="text-xs uppercase tracking-[0.3em] text-white/50">Scroll</span>
+            <div className="scroll-indicator" aria-hidden="true" />
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/components/landing/OperationsSection.tsx
+++ b/src/components/landing/OperationsSection.tsx
@@ -1,0 +1,37 @@
+import type { operationsHighlights } from '@/data/landing'
+
+interface OperationsSectionProps {
+  highlights: typeof operationsHighlights
+}
+
+export default function OperationsSection({ highlights }: OperationsSectionProps) {
+  return (
+    <section id="operations" className="bg-lundies-ivory py-24">
+      <div className="mx-auto w-full max-w-6xl px-6">
+        <header className="max-w-2xl space-y-4" data-reveal>
+          <p className="text-xs font-semibold uppercase tracking-[0.4em] text-lundies-moss">Operations</p>
+          <h2 className="text-3xl sm:text-4xl">Empowering teams behind the scenes</h2>
+          <p className="text-base text-lundies-peat">
+            Interfaces choreographed for operations, revenue, and guest relations to collaborate in real time.
+          </p>
+        </header>
+
+        <div className="mt-16 grid gap-8 md:grid-cols-3" data-reveal>
+          {highlights.map((highlight) => (
+            <article key={highlight.title} className="space-y-5 rounded-[2rem] border border-lundies-stone/60 bg-white/80 p-6">
+              <h3 className="text-2xl">{highlight.title}</h3>
+              <ul className="space-y-3 text-sm text-lundies-peat">
+                {highlight.points.map((point) => (
+                  <li key={point} className="flex items-start gap-3">
+                    <span aria-hidden="true" className="mt-1 inline-block h-1.5 w-1.5 rounded-full bg-lundies-moss" />
+                    <span>{point}</span>
+                  </li>
+                ))}
+              </ul>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/components/landing/RoomsSection.tsx
+++ b/src/components/landing/RoomsSection.tsx
@@ -1,0 +1,63 @@
+import Image from 'next/image'
+import Link from 'next/link'
+
+import type { roomCollections } from '@/data/landing'
+
+interface RoomsSectionProps {
+  rooms: typeof roomCollections
+}
+
+export default function RoomsSection({ rooms }: RoomsSectionProps) {
+  return (
+    <section id="rooms" className="bg-lundies-ivory py-24">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-12 px-6">
+        <header className="max-w-2xl space-y-4" data-reveal>
+          <p className="text-xs font-semibold uppercase tracking-[0.4em] text-lundies-moss">Rooms & suites</p>
+          <h2 className="text-3xl sm:text-4xl">Tailored stays for every travel story</h2>
+          <p className="text-base text-lundies-peat">
+            Each room is staged for photography, future availability widgets, and campaign-ready storytelling.
+          </p>
+        </header>
+
+        <div className="space-y-16">
+          {rooms.map((room, index) => (
+            <article
+              key={room.name}
+              className={`grid gap-10 md:grid-cols-2 md:items-center ${index % 2 === 1 ? 'md:grid-flow-col-dense' : ''}`}
+            >
+              <div className="relative aspect-[4/3] overflow-hidden rounded-[2.5rem] bg-lundies-stone/40" data-reveal>
+                <Image
+                  src={room.image}
+                  alt={room.name}
+                  fill
+                  sizes="(min-width: 768px) 50vw, 100vw"
+                  className="object-cover"
+                  loading={index === 0 ? 'eager' : 'lazy'}
+                />
+              </div>
+              <div className="space-y-6" data-reveal>
+                <p className="text-xs uppercase tracking-[0.4em] text-lundies-moss">{room.meta}</p>
+                <h3 className="text-3xl">{room.name}</h3>
+                <p className="text-base text-lundies-peat">{room.summary}</p>
+                <div className="flex flex-wrap gap-3">
+                  <Link
+                    href="/rooms"
+                    className="rounded-full border border-lundies-stone px-5 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-lundies-charcoal transition hover:bg-white"
+                  >
+                    Room details
+                  </Link>
+                  <Link
+                    href="/booking"
+                    className="rounded-full bg-lundies-heather px-5 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-lundies-charcoal transition hover:bg-lundies-heather/80"
+                  >
+                    Check availability
+                  </Link>
+                </div>
+              </div>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/components/landing/TechnologySection.tsx
+++ b/src/components/landing/TechnologySection.tsx
@@ -1,0 +1,33 @@
+import type { technologyPillars } from '@/data/landing'
+
+interface TechnologySectionProps {
+  pillars: typeof technologyPillars
+}
+
+export default function TechnologySection({ pillars }: TechnologySectionProps) {
+  return (
+    <section id="technology" className="bg-white py-24">
+      <div className="mx-auto w-full max-w-6xl px-6">
+        <header className="max-w-2xl space-y-4" data-reveal>
+          <p className="text-xs font-semibold uppercase tracking-[0.4em] text-lundies-moss">Technology</p>
+          <h2 className="text-3xl sm:text-4xl">The platform behind the poise</h2>
+          <p className="text-base text-lundies-peat">
+            Modular services keep the guest journey quick, personalised, and future-friendly.
+          </p>
+        </header>
+
+        <div className="mt-16 grid gap-8 md:grid-cols-2" data-reveal>
+          {pillars.map((pillar) => (
+            <article
+              key={pillar.title}
+              className="space-y-4 rounded-[2rem] border border-lundies-stone/60 bg-lundies-linen/80 p-8 shadow-sm"
+            >
+              <h3 className="text-2xl">{pillar.title}</h3>
+              <p className="text-sm text-lundies-peat">{pillar.detail}</p>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/components/navigation/SiteNavigation.tsx
+++ b/src/components/navigation/SiteNavigation.tsx
@@ -23,6 +23,7 @@ interface SiteNavigationProps {
   className?: string
   layout?: 'landing' | 'standard'
   sectionLinks?: NavigationLink[]
+  isSticky?: boolean
 }
 
 const basePrimaryClasses =
@@ -71,13 +72,20 @@ export default function SiteNavigation({
   className = '',
   layout = 'landing',
   sectionLinks = [],
+  isSticky = false,
 }: SiteNavigationProps) {
   const pathname = usePathname()
   const palette = palettes[layout]
+  const stickyClasses = isSticky
+    ? 'sticky top-0 z-50 border-b border-white/40 bg-[rgba(245,241,235,0.82)] backdrop-blur-lg'
+    : ''
 
   return (
-    <div className={`flex flex-col gap-4 text-lundies-charcoal ${className}`}>
-      <div className="flex flex-col gap-4 md:grid md:grid-cols-[auto,1fr,auto] md:items-center">
+    <nav
+      className={`flex flex-col gap-4 text-lundies-charcoal transition-colors duration-500 ease-out ${stickyClasses} ${className}`}
+      aria-label="Primary"
+    >
+      <div className="flex flex-col gap-4 px-4 py-5 md:grid md:grid-cols-[auto,1fr,auto] md:items-center md:px-10">
         <Link href="/" className="font-semibold tracking-wide text-lundies-charcoal">
           Schiehallion Hotel
         </Link>
@@ -117,8 +125,8 @@ export default function SiteNavigation({
       </div>
 
       {sectionLinks.length > 0 ? (
-        <div className="-mx-2 overflow-x-auto">
-          <div className="flex min-w-fit items-center gap-2 px-2 md:flex-wrap md:justify-center">
+        <div className="-mx-2 overflow-x-auto border-t border-white/40">
+          <div className="flex min-w-fit items-center gap-2 px-6 py-3 md:flex-wrap md:justify-center">
             {sectionLinks.map((link) => (
               <Link key={link.label} href={link.href} className={`${baseSectionClasses} ${palette.section}`}>
                 {link.label}
@@ -127,6 +135,6 @@ export default function SiteNavigation({
           </div>
         </div>
       ) : null}
-    </div>
+    </nav>
   )
 }

--- a/src/config/contact.ts
+++ b/src/config/contact.ts
@@ -1,0 +1,5 @@
+export const contactChannels = [
+  { label: 'Visit', detail: '1-5 Dunkeld Street, Aberfeldy, PH15 2AA', href: 'https://maps.app.goo.gl/qxgTB1gYkn12' },
+  { label: 'Reserve', detail: '+44 (0)1887 352 214', href: 'tel:+441887352214' },
+  { label: 'Enquire', detail: 'hello@schiehallionhotel.co.uk', href: 'mailto:hello@schiehallionhotel.co.uk' },
+]

--- a/src/data/landing.ts
+++ b/src/data/landing.ts
@@ -1,0 +1,141 @@
+export const landingSections = [
+  { label: 'Story', href: '#story' },
+  { label: 'Rooms', href: '#rooms' },
+  { label: 'Dining', href: '#dining' },
+  { label: 'Experiences', href: '#experiences' },
+  { label: 'Technology', href: '#technology' },
+  { label: 'Operations', href: '#operations' },
+  { label: 'Awards', href: '#awards' },
+  { label: 'Contact', href: '#contact' },
+]
+
+export const heroImages = [
+  {
+    src: '/images/rooms/generated/suite/suite-artistic-1759248824246-ur9015.png',
+    alt: 'Soft morning light inside the Schiehallion loft suite',
+    caption: 'Loch Tay suites with tailored service',
+  },
+  {
+    src: '/images/rooms/generated/deluxe/deluxe-artistic-1759248801864-outd2c.png',
+    alt: 'Deluxe room featuring freestanding bath and herringbone floors',
+    caption: 'Deluxe comforts with Highland textures',
+  },
+  {
+    src: '/images/rooms/generated/family/family-artistic-1759248840189-b78zgy.png',
+    alt: 'Family suite with warm timber panelling and seating nook',
+    caption: 'Family suites crafted for together time',
+  },
+]
+
+export const roomCollections = [
+  {
+    name: 'Highland View Double',
+    summary: 'Loch-side calm, super-king sleep, fresh pastries on cue.',
+    image: '/images/rooms/generated/standard/standard-artistic-1759248767421-r0mln6.png',
+    meta: 'Signature Double · 2 adults + child',
+  },
+  {
+    name: 'Riverside Twin Retreat',
+    summary: 'Twin comfort with ergonomic workspace and ultrafast Wi-Fi.',
+    image: '/images/rooms/generated/accessible/accessible-artistic-1759248857443-57441r.png',
+    meta: 'Twin · Work-ready sanctuary',
+  },
+  {
+    name: 'Family Cairngorm Suite',
+    summary: 'Interconnected rooms, games chest, and concierge planning.',
+    image: '/images/rooms/generated/family/family-artistic-1759248840189-b78zgy.png',
+    meta: 'Two-bedroom suite · 2 adults · 2 children',
+  },
+  {
+    name: 'Deluxe Schiehallion Loft',
+    summary: 'Freestanding bath, private check-in, telescope over Ben Lawers.',
+    image: '/images/rooms/generated/deluxe/deluxe-artistic-1759248801864-outd2c.png',
+    meta: 'Loft suite · Celebrations',
+  },
+]
+
+export const diningMoments = [
+  {
+    title: 'The Schiehallion Kitchen',
+    description: 'Seasonal tasting journeys with Perthshire produce and sommelier pairings.',
+    image: '/images/rooms/generated/suite/suite-artistic-1759248824246-ur9015.png',
+    highlights: ['Four-course tasting', 'Vegan pairings', 'Wine flights'],
+  },
+  {
+    title: 'Breakfast & Brunch',
+    description: 'Sunrise spreads, Glen Lyon coffee, and take-away baskets for river guides.',
+    image: '/images/rooms/generated/standard/standard-artistic-1759248767421-r0mln6.png',
+    highlights: ['Fresh pastries', 'Express takeaway', 'Locally roasted beans'],
+  },
+  {
+    title: 'Afternoon Rituals',
+    description: 'Highland shortbread towers, live roast countdown, patisserie made in-house.',
+    image: '/images/rooms/generated/accessible/accessible-artistic-1759248857443-57441r.png',
+    highlights: ['Seasonal tea menu', 'Allergen aware', 'Sunday roast theatre'],
+  },
+]
+
+export const experienceStories = [
+  {
+    name: 'Dewars Aberfeldy Distillery',
+    distance: '2 miles',
+    description: 'Heritage tastings, storytelling lounges, bespoke whisky flights.',
+  },
+  {
+    name: 'Beyond Adventure',
+    distance: 'On the River Tay',
+    description: 'Kayaking, paddleboarding, and private guides for every level.',
+  },
+  {
+    name: 'Loch Tay & Ben Lawers',
+    distance: '15 minutes',
+    description: 'Sunrise hikes, photographer-led expeditions, snowline picnics.',
+  },
+  {
+    name: 'Aberfeldy Watermill & Gallery',
+    distance: '5 minute walk',
+    description: 'Independent bookshop, art exhibitions, slow-travel inspiration.',
+  },
+]
+
+export const technologyPillars = [
+  {
+    title: 'Unified Booking Surface',
+    detail:
+      'Next.js 15 powering responsive web, PWA, and admin journeys with shared tokens and inclusive patterns.',
+  },
+  {
+    title: 'Real-time Availability Core',
+    detail: 'Firestore + Realtime Database syncing room calendars, dining tables, and partner allotments.',
+  },
+  {
+    title: 'Edge-first Performance',
+    detail: 'CDN image optimisation, caching strategies, and sub-100ms first content worldwide.',
+  },
+  {
+    title: 'Payments & Assurance',
+    detail: 'Stripe integrations with 3D Secure, automated confirmations, and audit-ready histories.',
+  },
+]
+
+export const operationsHighlights = [
+  {
+    title: 'Operations Command Centre',
+    points: ['Drag-and-drop room assignment', 'Housekeeping snapshots', 'Proactive maintenance alerts'],
+  },
+  {
+    title: 'Revenue Studio',
+    points: ['Dynamic pricing experiments', 'Package performance analytics', 'Competitive benchmarks'],
+  },
+  {
+    title: 'Guest Relationship Desk',
+    points: ['Unified inbox', 'Pre-arrival and post-stay flows', 'Loyalty segmentation'],
+  },
+]
+
+export const awards = [
+  { label: 'Scottish Hotel Awards', detail: 'Boutique Hotel of the Year · 2023' },
+  { label: 'Green Key Certification', detail: 'Sustainable operations accreditation' },
+  { label: 'VisitScotland', detail: '5-Star Gold Guest Accommodation' },
+  { label: 'Condé Nast Traveller', detail: 'Readers Choice Top 20 Highlands' },
+]

--- a/src/hooks/usePrefersReducedMotion.ts
+++ b/src/hooks/usePrefersReducedMotion.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react'
+
+export function usePrefersReducedMotion() {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false)
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)')
+    const handleChange = () => setPrefersReducedMotion(mediaQuery.matches)
+
+    handleChange()
+    mediaQuery.addEventListener('change', handleChange)
+
+    return () => mediaQuery.removeEventListener('change', handleChange)
+  }, [])
+
+  return prefersReducedMotion
+}

--- a/src/hooks/useRevealOnScroll.ts
+++ b/src/hooks/useRevealOnScroll.ts
@@ -1,0 +1,38 @@
+import { useEffect } from 'react'
+
+export function useRevealOnScroll(prefersReducedMotion: boolean) {
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+
+    const revealElements = document.querySelectorAll<HTMLElement>('[data-reveal]')
+
+    if (!revealElements.length) return
+
+    if (prefersReducedMotion) {
+      revealElements.forEach((element) => {
+        element.classList.add('reveal-visible')
+      })
+      return
+    }
+
+    revealElements.forEach((element) => {
+      element.classList.add('reveal-element')
+    })
+
+    const observer = new IntersectionObserver(
+      (entries, obs) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('reveal-visible')
+            obs.unobserve(entry.target)
+          }
+        })
+      },
+      { threshold: 0.15, rootMargin: '0px 0px -10% 0px' },
+    )
+
+    revealElements.forEach((element) => observer.observe(element))
+
+    return () => observer.disconnect()
+  }, [prefersReducedMotion])
+}


### PR DESCRIPTION
## Summary
- refresh the global typography and palette to support a minimalist luxury aesthetic while keeping smooth scroll and reveal utilities
- rebuild the home page as a single scrolling narrative with hero carousel, modular room and dining showcases, experiences, technology, operations, awards, and contact sections
- update the site navigation to a sticky, blurred bar with optional call-to-action controls and modal sign-in access

## Testing
- npm run lint *(fails: pre-existing lint violations across unrelated legacy scripts and tests)*

------
https://chatgpt.com/codex/tasks/task_e_68dc1965f3508332827f252d3da3a2f7